### PR TITLE
build: add -fPIC for fixing relocation in shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,7 @@ endif()
 
 # Add board-dependant flags
 iotjs_add_compile_flags(-DTARGET_BOARD=${TARGET_BOARD})
+iotjs_add_compile_flags(-fPIC)
 
 if("${TARGET_BOARD}" STREQUAL "artik05x")
   iotjs_add_compile_flags(-mcpu=cortex-r4 -mfpu=vfp3)


### PR DESCRIPTION
This adds -fPIC to fix the shared library linking problem on Linux :)