### PR TITLE
module: prints the latest loaded module id when syntax error

### DIFF
--- a/src/js/iotjs.js
+++ b/src/js/iotjs.js
@@ -118,10 +118,15 @@
     nextTick(callback);
   }
 
+  var module = Module.require('module');
 
   process._onUncaughtException = _onUncaughtException;
   function _onUncaughtException(error) {
     var event = 'uncaughtException';
+    if (error instanceof SyntaxError) {
+      error.message = `${error.message} at\n\t ${module.curr}`;
+    }
+
     if (process._events[event] && process._events[event].length > 0) {
       try {
         // Emit uncaughtException event.

--- a/src/js/module.js
+++ b/src/js/module.js
@@ -31,6 +31,7 @@ module.exports = iotjs_module_t;
 iotjs_module_t.cache = {};
 iotjs_module_t.wrapper = Native.wrapper;
 iotjs_module_t.wrap = Native.wrap;
+iotjs_module_t.curr = null;
 
 
 var cwd;
@@ -182,6 +183,7 @@ iotjs_module_t.tryPath = function(path) {
 
 iotjs_module_t.load = function(id, parent) {
   if (process.builtin_modules[id]) {
+    iotjs_module_t.curr = id;
     return Native.require(id);
   }
   var module = new iotjs_module_t(id, parent);
@@ -190,6 +192,7 @@ iotjs_module_t.load = function(id, parent) {
 
   var cachedModule = iotjs_module_t.cache[modPath];
   if (cachedModule) {
+    iotjs_module_t.curr = modPath;
     return cachedModule.exports;
   }
 
@@ -201,6 +204,7 @@ iotjs_module_t.load = function(id, parent) {
   module.filename = modPath;
   module.dirs = [modPath.substring(0, modPath.lastIndexOf('/') + 1)];
   iotjs_module_t.cache[modPath] = module;
+  iotjs_module_t.curr = modPath;
 
   var ext = modPath.substr(modPath.lastIndexOf('.') + 1);
   if (ext === 'js') {


### PR DESCRIPTION
This prints the `SyntaxError`'s source file as:

```shell
uncaughtException: SyntaxError: Primary expression expected. [line: 4, column: 2] at
    /Users/yorkieliu/workspace/shadownode-debug-playground/bar.js
```