### PR TITLE
tls: bug fix

### DIFF
--- a/src/js/mqtt.js
+++ b/src/js/mqtt.js
@@ -151,14 +151,20 @@ MqttClient.prototype._keepAlive = function() {
  * @param {Function} callback
  */
 MqttClient.prototype.publish = function(topic, payload, options, callback) {
-  var buf = this._handle._getPublish(topic, {
-    id: this._msgId++,
-    qos: (options && options.qos) || 0,
-    dup: (options && options.dup) || false,
-    retain: (options && options.retain) || false,
-    payload: payload || '',
-  });
-  this._write(buf);
+  var buf;
+  try {
+    buf = this._handle._getPublish(topic, {
+      id: this._msgId++,
+      qos: (options && options.qos) || 0,
+      dup: (options && options.dup) || false,
+      retain: (options && options.retain) || false,
+      payload: payload || '',
+    });
+  } catch (err) {
+    callback(err);
+    return;
+  }
+  this._write(buf, callback);
 };
 
 /**

--- a/src/js/mqtt.js
+++ b/src/js/mqtt.js
@@ -151,20 +151,18 @@ MqttClient.prototype._keepAlive = function() {
  * @param {Function} callback
  */
 MqttClient.prototype.publish = function(topic, payload, options, callback) {
-  var buf;
   try {
-    buf = this._handle._getPublish(topic, {
+    var buf = this._handle._getPublish(topic, {
       id: this._msgId++,
       qos: (options && options.qos) || 0,
       dup: (options && options.dup) || false,
       retain: (options && options.retain) || false,
       payload: payload || '',
     });
+    this._write(buf, callback);
   } catch (err) {
     callback(err);
-    return;
   }
-  this._write(buf, callback);
 };
 
 /**

--- a/src/js/tls.js
+++ b/src/js/tls.js
@@ -98,9 +98,13 @@ TLSSocket.prototype.write = function(data, cb) {
     }
     var chunk = data.slice(sourceStart, sourceStart + sourceLength);
     sourceStart += sourceLength;
-    var encodedChunk = this._tls.write(chunk);
-    if (!Buffer.isBuffer(encodedChunk)) {
-      throw new Error('Encryption is not available');
+    var encodedChunk;
+    try {
+      // tls.write may throw error if iotjs_tlswrap_encode_data failure
+      encodedChunk = this._tls.write(chunk);
+    } catch (err) {
+      cb(err);
+      return false;
     }
     chunks.push(encodedChunk);
   }

--- a/src/js/tls.js
+++ b/src/js/tls.js
@@ -6,7 +6,7 @@ var net = require('net');
 var util = require('util');
 var EventEmitter = require('events').EventEmitter;
 var TlsWrap = native.TlsWrap;
-var TLS_CHUNK_MAX_SIZE = TlsWrap.TLS_CHUNK_MAX_SIZE;
+var TLS_CHUNK_MAX_SIZE = require('constants').TLS_CHUNK_MAX_SIZE;
 
 function TLSSocket(socket, opts) {
   if (!(this instanceof TLSSocket))

--- a/src/modules/iotjs_module_constants.c
+++ b/src/modules/iotjs_module_constants.c
@@ -15,12 +15,18 @@
 
 #include "iotjs_def.h"
 #include "iotjs_module.h"
-
+#include "mbedtls/ssl.h"
 
 #define SET_CONSTANT(object, constant)                           \
   do {                                                           \
     iotjs_jval_set_property_number(object, #constant, constant); \
   } while (0)
+
+#ifdef MBEDTLS_SSL_MAX_CONTENT_LEN
+#define TLS_CHUNK_MAX_SIZE MBEDTLS_SSL_MAX_CONTENT_LEN
+#else
+#define TLS_CHUNK_MAX_SIZE INT_MAX
+#endif
 
 jerry_value_t InitConstants() {
   jerry_value_t constants = jerry_create_object();
@@ -39,6 +45,7 @@ jerry_value_t InitConstants() {
   SET_CONSTANT(constants, S_IFREG);
   SET_CONSTANT(constants, S_IFLNK);
   SET_CONSTANT(constants, S_IFSOCK);
+  SET_CONSTANT(constants, TLS_CHUNK_MAX_SIZE);
 
   // define uv errnos
 #define V(name, _) SET_CONSTANT(constants, UV_##name);

--- a/src/modules/iotjs_module_mqtt.c
+++ b/src/modules/iotjs_module_mqtt.c
@@ -155,8 +155,11 @@ JS_FUNCTION(MqttGetConnect) {
 
 
 void alloc_payload_buf(unsigned char **buf, int expected_size, int *alloc_size) {
-  static const int buf_size = 1 * 1024 * 1024;
-  static unsigned char buf_[buf_size];
+  static int buf_size = 1 * 1024 * 1024;
+  static unsigned char *buf_ = NULL;
+  if (buf_ == NULL) {
+    buf_ = malloc((size_t)buf_size * sizeof(unsigned char));
+  }
   if (expected_size > buf_size) {
     return;
   }

--- a/src/modules/iotjs_module_tls.c
+++ b/src/modules/iotjs_module_tls.c
@@ -235,9 +235,16 @@ JS_FUNCTION(TlsConstructor) {
 
 jerry_value_t iotjs_tlswrap_encode_data(iotjs_tlswrap_t_impl_t* _this, 
                                         iotjs_bufferwrap_t* inbuf) {
+  /*
+    inbuf length should less equal than MBEDTLS_SSL_MAX_CONTENT_LEN which is 16384 bytes
+  */
+  size_t inbuf_len = iotjs_bufferwrap_length(inbuf);
+  if (inbuf_len > MBEDTLS_SSL_MAX_CONTENT_LEN) {
+    return JS_CREATE_ERROR(COMMON, "tls encode data is too large");
+  }
   size_t rv = (size_t)mbedtls_ssl_write(&_this->ssl_, 
                                         (const unsigned char*)iotjs_bufferwrap_buffer(inbuf),
-                                        iotjs_bufferwrap_length(inbuf));
+                                        inbuf_len);
   size_t pending = 0;
   if ((pending = iotjs_bio_ctrl_pending(_this->app_bio_)) > 0) {
     const char tmpbuf[pending];

--- a/src/modules/iotjs_module_tls.c
+++ b/src/modules/iotjs_module_tls.c
@@ -409,6 +409,12 @@ jerry_value_t InitTls() {
   iotjs_jval_set_method(proto, "end", TlsEnd);
   iotjs_jval_set_property_jval(tlsConstructor, "prototype", proto);
 
+#ifdef MBEDTLS_SSL_MAX_CONTENT_LEN
+  iotjs_jval_set_property_number(tlsConstructor, "TLS_CHUNK_MAX_SIZE", MBEDTLS_SSL_MAX_CONTENT_LEN);
+#else
+  iotjs_jval_set_property_number(tlsConstructor, "TLS_CHUNK_MAX_SIZE", INT_MAX);
+#endif
+
   jerry_release_value(proto);
   jerry_release_value(tlsConstructor);
   return tls;

--- a/src/modules/iotjs_module_tls.c
+++ b/src/modules/iotjs_module_tls.c
@@ -235,9 +235,9 @@ JS_FUNCTION(TlsConstructor) {
 
 jerry_value_t iotjs_tlswrap_encode_data(iotjs_tlswrap_t_impl_t* _this, 
                                         iotjs_bufferwrap_t* inbuf) {
-  /*
-    inbuf length should less equal than MBEDTLS_SSL_MAX_CONTENT_LEN which is 16384 bytes
-  */
+  /**
+   * inbuf length should less equal than MBEDTLS_SSL_MAX_CONTENT_LEN which is 16384 bytes
+   */
   size_t inbuf_len = iotjs_bufferwrap_length(inbuf);
   if (inbuf_len > MBEDTLS_SSL_MAX_CONTENT_LEN) {
     return JS_CREATE_ERROR(COMMON, "tls encode data is too large");
@@ -256,7 +256,7 @@ jerry_value_t iotjs_tlswrap_encode_data(iotjs_tlswrap_t_impl_t* _this,
     iotjs_bufferwrap_copy(outbuf, (const char*)tmpbuf, rv);
     return out;
   } else {
-    return jerry_create_null();
+    return JS_CREATE_ERROR(COMMON, "tls encode data failure");
   }
 }
 

--- a/src/modules/iotjs_module_tls.c
+++ b/src/modules/iotjs_module_tls.c
@@ -409,12 +409,6 @@ jerry_value_t InitTls() {
   iotjs_jval_set_method(proto, "end", TlsEnd);
   iotjs_jval_set_property_jval(tlsConstructor, "prototype", proto);
 
-#ifdef MBEDTLS_SSL_MAX_CONTENT_LEN
-  iotjs_jval_set_property_number(tlsConstructor, "TLS_CHUNK_MAX_SIZE", MBEDTLS_SSL_MAX_CONTENT_LEN);
-#else
-  iotjs_jval_set_property_number(tlsConstructor, "TLS_CHUNK_MAX_SIZE", INT_MAX);
-#endif
-
   jerry_release_value(proto);
   jerry_release_value(tlsConstructor);
   return tls;


### PR DESCRIPTION
- limit buffer size with 16k(defined by MBEDTLS_SSL_MAX_CONTENT_LEN) for iotjs_tlswrap_encode_data
- tls encode incoming data multi times when data is larger than 16k
- alloc 1m heap memroy for MqttGetPublish buffer instead of dynamic stack memory