### PR TITLE
buffer: fix readInt methods, should use builtin uint

### DIFF
--- a/src/js/buffer.js
+++ b/src/js/buffer.js
@@ -341,8 +341,10 @@ Buffer.prototype.readInt16LE = function(offset, noAssert) {
   offset = offset >>> 0;
   if (!noAssert)
     checkOffset(offset, 2, this.length);
-  return this.readInt8(offset) |
-         (this.readInt8(offset + 1) << 8);
+
+  var val = this._builtin.readUInt8(offset) | 
+    (this._builtin.readUInt8(offset + 1) << 8);
+  return (val & 0x8000) ? val | 0xFFFF0000 : val;
 };
 
 
@@ -353,10 +355,10 @@ Buffer.prototype.readInt32LE = function(offset, noAssert) {
   offset = offset >>> 0;
   if (!noAssert)
     checkOffset(offset, 4, this.length);
-  return this.readInt8(offset) |
-         (this.readInt8(offset + 1) << 8) |
-         (this.readInt8(offset + 2) << 16) |
-         (this.readInt8(offset + 3) << 24);
+  return this._builtin.readUInt8(offset) |
+         (this._builtin.readUInt8(offset + 1) << 8) |
+         (this._builtin.readUInt8(offset + 2) << 16) |
+         (this._builtin.readUInt8(offset + 3) << 24);
 };
 
 

--- a/test/run_pass/test_buffer.js
+++ b/test/run_pass/test_buffer.js
@@ -182,3 +182,7 @@ var buff18 = new Buffer(4);
 var ret = buff18.fill(7);
 assert.equal(buff18.readInt16LE(0), 1799);
 assert.equal(buff18.readInt32LE(0), 117901063);
+
+var buff19 = new Buffer([0xb5, 0x01]);
+assert.equal(buff19.readInt16LE(0), 437);
+


### PR DESCRIPTION
This fixes `new Buffer([0xb5, 0x01])` return the negative number :)