### PR TITLE
build: fix the staging and target installing path

### DIFF
--- a/cmake/iotjs.cmake
+++ b/cmake/iotjs.cmake
@@ -437,8 +437,6 @@ if("${BIN_INSTALL_DIR}" STREQUAL "")
   set(BIN_INSTALL_DIR "bin")
 endif()
 
-install(TARGETS ${TARGET_LIB_IOTJS} DESTINATION ${LIB_INSTALL_DIR})
-
 # Configure the iotjs executable
 if(NOT BUILD_LIB_ONLY)
   set(TARGET_IOTJS iotjs)
@@ -453,4 +451,6 @@ if(NOT BUILD_LIB_ONLY)
           RUNTIME DESTINATION "${INSTALL_PREFIX}/bin"
           LIBRARY DESTINATION "${INSTALL_PREFIX}/lib"
           PUBLIC_HEADER DESTINATION "${INSTALL_PREFIX}/include/shadow-node")
+else()
+  install(TARGETS ${TARGET_LIB_IOTJS} DESTINATION ${LIB_INSTALL_DIR})
 endif()


### PR DESCRIPTION
Should not re-install the library when not in library only. This fixes the installing issue on /usr/lib and /lib.