### PR TITLE
stacktrace: attach stack trace to error instance

### DIFF
--- a/deps/jerry/jerry-core/api/jerry.c
+++ b/deps/jerry/jerry-core/api/jerry.c
@@ -3382,29 +3382,21 @@ jerry_flush_parser_dump_file (void)
 }
 
 uint32_t*
-jerry_get_stacktrace (void)
+jerry_get_backtrace (void)
 {
   jerry_assert_api_available ();
   return JERRY_CONTEXT (stack_frames);
 }
 
 void
-jerry_get_stacktrace_depth (uint32_t *stack_frames, uint32_t depth)
+jerry_get_backtrace_depth (uint32_t *frames, uint32_t depth)
 {
   jerry_assert_api_available ();
-
-  vm_frame_ctx_t *ctx_p = JERRY_CONTEXT (vm_top_context_p);
-  for (uint32_t idx = 0; idx < depth && ctx_p != NULL; ++idx) {
-    jmem_cpointer_t byte_code_cp;
-    JMEM_CP_SET_NON_NULL_POINTER (byte_code_cp, ctx_p->bytecode_header_p);
-    stack_frames[idx] = (uint32_t) byte_code_cp;
-
-    ctx_p = ctx_p->prev_context_p;
-  }
+  jcontext_get_backtrace_depth(frames, depth);
 }
 
 uint32_t
-jerry_get_stacktrace_max_depth (void)
+jerry_get_backtrace_max_depth (void)
 {
   jerry_assert_api_available ();
   return 10;

--- a/deps/jerry/jerry-core/ecma/operations/ecma-exceptions.c
+++ b/deps/jerry/jerry-core/ecma/operations/ecma-exceptions.c
@@ -134,6 +134,32 @@ ecma_new_standard_error (ecma_standard_error_t error_type) /**< native error typ
 
   ((ecma_extended_object_t *) new_error_obj_p)->u.class_prop.class_id = LIT_MAGIC_STRING_ERROR_UL;
 
+  const char *frames_id_p = "__frames__";
+
+  ecma_string_t *frames_str_p = ecma_new_ecma_string_from_utf8 ((const lit_utf8_byte_t *) frames_id_p, 10);
+
+  ecma_property_value_t *prop_value_p = ecma_create_named_data_property (new_error_obj_p,
+                                                                         frames_str_p,
+                                                                         ECMA_PROPERTY_CONFIGURABLE_WRITABLE,
+                                                                         NULL);
+  ecma_deref_ecma_string (frames_str_p);
+
+  uint32_t depth = 10;
+  // create frames
+  uint32_t* frames = malloc(sizeof(uint32_t) * depth);
+  memset(frames, 0, sizeof(uint32_t) * depth);
+  jerry_get_stacktrace_depth(frames, depth);
+
+  jerry_value_t jframes = jerry_create_array(depth);
+  for (uint32_t i = 0; i < depth; ++i) {
+    jerry_set_property_by_index(jframes, i, jerry_create_number(frames[i]));
+  }
+
+  free(frames);
+
+  prop_value_p->value = jframes;
+  ecma_deref_object (ecma_get_object_from_value (jframes));
+
   return new_error_obj_p;
 } /* ecma_new_standard_error */
 

--- a/deps/jerry/jerry-core/ecma/operations/ecma-exceptions.c
+++ b/deps/jerry/jerry-core/ecma/operations/ecma-exceptions.c
@@ -15,8 +15,8 @@
 
 #include <stdarg.h>
 #include <stdlib.h>
+#include "ecma-array-object.h"
 #include "ecma-builtins.h"
-#include "ecma-builtin-helpers.h"
 #include "ecma-conversion.h"
 #include "ecma-exceptions.h"
 #include "ecma-gc.h"

--- a/deps/jerry/jerry-core/ecma/operations/ecma-exceptions.c
+++ b/deps/jerry/jerry-core/ecma/operations/ecma-exceptions.c
@@ -14,6 +14,7 @@
  */
 
 #include <stdarg.h>
+#include <stdlib.h>
 #include "ecma-builtins.h"
 #include "ecma-conversion.h"
 #include "ecma-exceptions.h"

--- a/deps/jerry/jerry-core/ecma/operations/ecma-exceptions.c
+++ b/deps/jerry/jerry-core/ecma/operations/ecma-exceptions.c
@@ -135,9 +135,9 @@ ecma_new_standard_error (ecma_standard_error_t error_type) /**< native error typ
 
   ((ecma_extended_object_t *) new_error_obj_p)->u.class_prop.class_id = LIT_MAGIC_STRING_ERROR_UL;
 
-  const char *frames_id_p = "__frames__";
+  const char *frames_id_p = "_frames";
 
-  ecma_string_t *frames_str_p = ecma_new_ecma_string_from_utf8 ((const lit_utf8_byte_t *) frames_id_p, 10);
+  ecma_string_t *frames_str_p = ecma_new_ecma_string_from_utf8 ((const lit_utf8_byte_t *) frames_id_p, 7);
 
   ecma_property_value_t *prop_value_p = ecma_create_named_data_property (new_error_obj_p,
                                                                          frames_str_p,
@@ -147,7 +147,7 @@ ecma_new_standard_error (ecma_standard_error_t error_type) /**< native error typ
 
   uint32_t depth = 10;
   // create frames
-  uint32_t* frames = malloc(sizeof(uint32_t) * depth);
+  uint32_t *frames = malloc(sizeof(uint32_t) * depth);
   memset(frames, 0, sizeof(uint32_t) * depth);
   jerry_get_stacktrace_depth(frames, depth);
 

--- a/deps/jerry/jerry-core/ecma/operations/ecma-exceptions.c
+++ b/deps/jerry/jerry-core/ecma/operations/ecma-exceptions.c
@@ -148,26 +148,29 @@ ecma_new_standard_error (ecma_standard_error_t error_type) /**< native error typ
 
   uint32_t depth = 10;
   // create frames
-  uint32_t *frames = malloc(sizeof(uint32_t) * depth);
-  memset(frames, 0, sizeof(uint32_t) * depth);
-  jcontext_get_backtrace_depth(frames, depth);
+  size_t frames_mem_size = sizeof (uint32_t) * depth;
+  uint32_t *frames = malloc (frames_mem_size);
+  JERRY_ASSERT (frames != NULL);
+  memset (frames, 0, frames_mem_size);
+  jcontext_get_backtrace_depth (frames, depth);
 
   ecma_value_t frames_array_length_val = ecma_make_uint32_value (depth);
   ecma_value_t frames_array = ecma_op_create_array_object (&frames_array_length_val, 1, true);
   ecma_free_value (frames_array_length_val);
   ecma_object_t *array_p = ecma_get_object_from_value (frames_array);
 
-  for (uint32_t i = 0; i < depth; ++i) {
+  for (uint32_t i = 0; i < depth; ++i)
+  {
     ecma_string_t *str_idx_p = ecma_new_ecma_string_from_uint32 ((uint32_t) i);
     ecma_property_value_t *index_prop_value_p = ecma_create_named_data_property (array_p,
-                                                                           str_idx_p,
-                                                                           ECMA_PROPERTY_CONFIGURABLE_WRITABLE,
-                                                                           NULL);
+                                                                                 str_idx_p,
+                                                                                 ECMA_PROPERTY_CONFIGURABLE_WRITABLE,
+                                                                                 NULL);
     ecma_deref_ecma_string (str_idx_p);
-    index_prop_value_p->value = ecma_make_uint32_value(frames[i]);
+    index_prop_value_p->value = ecma_make_uint32_value (frames[i]);
   }
 
-  free(frames);
+  free (frames);
 
   prop_value_p->value = frames_array;
   ecma_deref_object (array_p);

--- a/deps/jerry/jerry-core/ecma/operations/ecma-exceptions.c
+++ b/deps/jerry/jerry-core/ecma/operations/ecma-exceptions.c
@@ -16,6 +16,7 @@
 #include <stdarg.h>
 #include <stdlib.h>
 #include "ecma-builtins.h"
+#include "ecma-builtin-helpers.h"
 #include "ecma-conversion.h"
 #include "ecma-exceptions.h"
 #include "ecma-gc.h"

--- a/deps/jerry/jerry-core/ecma/operations/ecma-exceptions.c
+++ b/deps/jerry/jerry-core/ecma/operations/ecma-exceptions.c
@@ -136,9 +136,9 @@ ecma_new_standard_error (ecma_standard_error_t error_type) /**< native error typ
 
   ((ecma_extended_object_t *) new_error_obj_p)->u.class_prop.class_id = LIT_MAGIC_STRING_ERROR_UL;
 
-  const char *frames_id_p = "_frames";
+  const char *frames_id_p = "__frames__";
 
-  ecma_string_t *frames_str_p = ecma_new_ecma_string_from_utf8 ((const lit_utf8_byte_t *) frames_id_p, 7);
+  ecma_string_t *frames_str_p = ecma_new_ecma_string_from_utf8 ((const lit_utf8_byte_t *) frames_id_p, 10);
 
   ecma_property_value_t *prop_value_p = ecma_create_named_data_property (new_error_obj_p,
                                                                          frames_str_p,

--- a/deps/jerry/jerry-core/include/jerryscript-core.h
+++ b/deps/jerry/jerry-core/include/jerryscript-core.h
@@ -527,9 +527,9 @@ bool jerry_set_parser_dump_file (char* path);
 bool jerry_cleanup_parser_dump_file (void);
 bool jerry_flush_parser_dump_file (void);
 
-uint32_t *jerry_get_stacktrace (void);
-void jerry_get_stacktrace_depth (uint32_t *stack_frames, uint32_t depth);
-uint32_t jerry_get_stacktrace_max_depth (void);
+uint32_t *jerry_get_backtrace (void);
+void jerry_get_backtrace_depth (uint32_t *stack_frames, uint32_t depth);
+uint32_t jerry_get_backtrace_max_depth (void);
 
 /**
  * @}

--- a/deps/jerry/jerry-core/jcontext/jcontext.c
+++ b/deps/jerry/jerry-core/jcontext/jcontext.c
@@ -52,9 +52,11 @@ jerry_hash_table_t jerry_global_hash_table;
 #endif /* !JERRY_ENABLE_EXTERNAL_CONTEXT */
 
 void
-jcontext_get_backtrace_depth (uint32_t *frames, uint32_t depth) {
+jcontext_get_backtrace_depth (uint32_t *frames, uint32_t depth)
+{
   vm_frame_ctx_t *ctx_p = JERRY_CONTEXT (vm_top_context_p);
-  for (uint32_t idx = 0; idx < depth && ctx_p != NULL; ++idx) {
+  for (uint32_t idx = 0; idx < depth && ctx_p != NULL; ++idx)
+  {
     jmem_cpointer_t byte_code_cp;
     JMEM_CP_SET_NON_NULL_POINTER (byte_code_cp, ctx_p->bytecode_header_p);
     frames[idx] = (uint32_t) byte_code_cp;

--- a/deps/jerry/jerry-core/jcontext/jcontext.c
+++ b/deps/jerry/jerry-core/jcontext/jcontext.c
@@ -51,6 +51,18 @@ jerry_hash_table_t jerry_global_hash_table;
 #endif /* !CONFIG_ECMA_LCACHE_DISABLE */
 #endif /* !JERRY_ENABLE_EXTERNAL_CONTEXT */
 
+void
+jcontext_get_backtrace_depth (uint32_t *frames, uint32_t depth) {
+  vm_frame_ctx_t *ctx_p = JERRY_CONTEXT (vm_top_context_p);
+  for (uint32_t idx = 0; idx < depth && ctx_p != NULL; ++idx) {
+    jmem_cpointer_t byte_code_cp;
+    JMEM_CP_SET_NON_NULL_POINTER (byte_code_cp, ctx_p->bytecode_header_p);
+    frames[idx] = (uint32_t) byte_code_cp;
+
+    ctx_p = ctx_p->prev_context_p;
+  }
+}
+
 /**
  * @}
  */

--- a/deps/jerry/jerry-core/jcontext/jcontext.h
+++ b/deps/jerry/jerry-core/jcontext/jcontext.h
@@ -288,6 +288,8 @@ extern jerry_hash_table_t jerry_global_hash_table;
 
 #endif /* JERRY_ENABLE_EXTERNAL_CONTEXT */
 
+void jcontext_get_backtrace_depth (uint32_t *frames, uint32_t depth);
+
 /**
  * @}
  */

--- a/src/iotjs_binding_helper.c
+++ b/src/iotjs_binding_helper.c
@@ -24,7 +24,7 @@ void iotjs_uncaught_exception(jerry_value_t jexception) {
   const jerry_value_t process = iotjs_module_get("process");
 
   // clean dump file
-  jerry_cleanup_parser_dump_file();
+  jerry_flush_parser_dump_file();
 
   // create frames
   uint32_t* frames = jerry_get_backtrace();

--- a/src/iotjs_binding_helper.c
+++ b/src/iotjs_binding_helper.c
@@ -27,8 +27,8 @@ void iotjs_uncaught_exception(jerry_value_t jexception) {
   jerry_cleanup_parser_dump_file();
 
   // create frames
-  uint32_t* frames = jerry_get_stacktrace();
-  uint32_t len = jerry_get_stacktrace_max_depth();
+  uint32_t* frames = jerry_get_backtrace();
+  uint32_t len = jerry_get_backtrace_max_depth();
   jerry_value_t jframes = jerry_create_array(len);
   for (uint32_t i = 0; i < len; i++) {
     jerry_set_property_by_index(jframes, i, jerry_create_number(frames[i]));

--- a/src/js/iotjs.js
+++ b/src/js/iotjs.js
@@ -201,7 +201,7 @@
     stack: {
       configurable: true,
       enumerable: false,
-      get: function () {
+      get: function() {
         if (this._stack === undefined) {
           process._flushParserDumpFile();
           this._stack = makeStackTraceFromDump(this._frames || []);
@@ -221,14 +221,15 @@
   Error.prepareStackTrace = prepareStackTrace;
   Error.captureStackTrace = function(throwable, terminator) {
     var frames = process._getStackFrames(11).slice(1);
-    Object.defineProperties(throwable, Object.assign({
+    var descriptor = Object.assign({
       _frames: {
         configurable: true,
         writable: true,
         enumerable: false,
         value: frames,
       },
-    }, stackPropertiesDescriptor));
+    }, stackPropertiesDescriptor);
+    Object.defineProperties(throwable, descriptor);
   };
 
   // Symbol

--- a/src/js/iotjs.js
+++ b/src/js/iotjs.js
@@ -207,7 +207,7 @@
       get: function () {
         if (this._stack === undefined) {
           process._flushParserDumpFile();
-          this._stack = makeStackTraceFromDump(this._frames);
+          this._stack = makeStackTraceFromDump(this._frames || []);
         }
         return this._stack;
       },

--- a/src/js/iotjs.js
+++ b/src/js/iotjs.js
@@ -92,13 +92,10 @@
   }
 
   process._onUncaughtException = _onUncaughtException;
-  function _onUncaughtException(error, frames) {
+  function _onUncaughtException(error) {
     var event = 'uncaughtException';
     if (error instanceof SyntaxError) {
       error.message = `${error.message} at\n    ${module.curr}`;
-    } else if (frames) {
-      var stacktrace = makeStackTraceFromDump(frames);
-      error.message += '\n' + stacktrace;
     }
     if (process._events[event] && process._events[event].length > 0) {
       try {

--- a/src/js/iotjs.js
+++ b/src/js/iotjs.js
@@ -197,7 +197,7 @@
   };
 
   function prepareStackTrace(throwable) {
-    return makeStackTraceFromDump(throwable.__frames__ || []);
+    return makeStackTraceFromDump(throwable._frames || []);
   }
 
   var stackPropertiesDescriptor = {
@@ -205,14 +205,14 @@
       configurable: true,
       enumerable: false,
       get: function () {
-        if (this.__stack__ === undefined) {
+        if (this._stack === undefined) {
           process._flushParserDumpFile();
-          this.__stack__ = makeStackTraceFromDump(this.__frames__);
+          this._stack = makeStackTraceFromDump(this._frames);
         }
-        return this.__stack__;
+        return this._stack;
       },
     },
-    __stack__: {
+    _stack: {
       configurable: true,
       writable: true,
       enumerable: false,
@@ -225,7 +225,7 @@
   Error.captureStackTrace = function(throwable, terminator) {
     var frames = process._getStackFrames(11).slice(1);
     Object.defineProperties(throwable, Object.assign({
-      __frames__: {
+      _frames: {
         configurable: true,
         writable: true,
         enumerable: false,

--- a/src/js/iotjs.js
+++ b/src/js/iotjs.js
@@ -194,7 +194,7 @@
   };
 
   function prepareStackTrace(throwable) {
-    return makeStackTraceFromDump(throwable._frames || []);
+    return makeStackTraceFromDump(throwable.__frames__ || []);
   }
 
   var stackPropertiesDescriptor = {
@@ -202,14 +202,14 @@
       configurable: true,
       enumerable: false,
       get: function() {
-        if (this._stack === undefined) {
+        if (this.__stack__ === undefined) {
           process._flushParserDumpFile();
-          this._stack = makeStackTraceFromDump(this._frames || []);
+          this.__stack__ = makeStackTraceFromDump(this.__frames__ || []);
         }
-        return this._stack;
+        return this.__stack__;
       },
     },
-    _stack: {
+    __stack__: {
       configurable: true,
       writable: true,
       enumerable: false,
@@ -222,7 +222,7 @@
   Error.captureStackTrace = function(throwable, terminator) {
     var frames = process._getStackFrames(11).slice(1);
     var descriptor = Object.assign({
-      _frames: {
+      __frames__: {
         configurable: true,
         writable: true,
         enumerable: false,

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -147,8 +147,11 @@ function formatValue(v) {
   if (v === null)
     return 'null';
 
-  if (v instanceof Error || 
-    v instanceof Date) {
+  if (v instanceof Error) {
+    return v.name + ': ' + v.message + '\n' + v.stack;
+  }
+
+  if (v instanceof Date) {
     return v.toString();
   }
 

--- a/src/modules/iotjs_module_process.c
+++ b/src/modules/iotjs_module_process.c
@@ -221,7 +221,7 @@ JS_FUNCTION(GetStackFrames) {
   // create frames
   uint32_t* frames = malloc(sizeof(uint32_t) * depth);
   memset(frames, 0, sizeof(uint32_t) * depth);
-  jerry_get_stacktrace_depth(frames, depth);
+  jerry_get_backtrace_depth(frames, depth);
 
   jerry_value_t jframes = jerry_create_array(depth);
   for (uint32_t i = 0; i < depth; ++i) {

--- a/test/node/parallel/test-http-catch-uncaughtexception.js
+++ b/test/node/parallel/test-http-catch-uncaughtexception.js
@@ -41,7 +41,7 @@ var assert = require('assert');
 var http = require('http');
 
 var uncaughtCallback = common.mustCall(function(er) {
-  assert.strictEqual(er.message, 'get did fail\n');
+  assert.strictEqual(er.message, 'get did fail');
 });
 
 process.on('uncaughtException', uncaughtCallback);

--- a/test/run_pass/test_iotjs_error_stack.js
+++ b/test/run_pass/test_iotjs_error_stack.js
@@ -1,0 +1,19 @@
+var assert = require('assert');
+
+var error = getError();
+assert(typeof error.stack === 'string');
+assert(error.stack.match(/^    at getError/));
+
+var plain = getPlainObject();
+assert(typeof plain.stack === 'string');
+assert(error.stack.match(/^    at getPlainObject/));
+
+function getError() {
+  return new Error('foobar');
+}
+
+function getPlainObject() {
+  var e = {};
+  Error.captureStackTrace(e);
+  return e;
+}

--- a/test/run_pass/test_iotjs_error_stack.js
+++ b/test/run_pass/test_iotjs_error_stack.js
@@ -6,7 +6,7 @@ assert(error.stack.match(/at getError/));
 
 var plain = getPlainObject();
 assert(typeof plain.stack === 'string');
-assert(error.stack.match(/at getPlainObject/));
+assert(plain.stack.match(/at getPlainObject/));
 
 function getError() {
   return new Error('foobar');

--- a/test/run_pass/test_iotjs_error_stack.js
+++ b/test/run_pass/test_iotjs_error_stack.js
@@ -2,11 +2,11 @@ var assert = require('assert');
 
 var error = getError();
 assert(typeof error.stack === 'string');
-assert(error.stack.match(/^    at getError/));
+assert(error.stack.match(/at getError/));
 
 var plain = getPlainObject();
 assert(typeof plain.stack === 'string');
-assert(error.stack.match(/^    at getPlainObject/));
+assert(error.stack.match(/at getPlainObject/));
 
 function getError() {
   return new Error('foobar');

--- a/test/run_pass/test_util.js
+++ b/test/run_pass/test_util.js
@@ -142,7 +142,7 @@ assert.equal(util.format('%j', '5001'), '"5001"');
 assert.equal(util.format('%d%d', 5001), '5001%d');
 assert.equal(util.format('%s%d%s%d', 'IoT.js ', 5001), 'IoT.js 5001%s%d');
 assert.equal(util.format('%d%% %s', 100, 'IoT.js'), '100% IoT.js');
-assert.equal(util.format(new Error('format')), 'Error: format');
+assert(util.format(new Error('format')).match(/^Error: format/));
 
 var err1 = util.errnoException(3008, 'syscall', 'original message');
 assert.equal(err1 instanceof Error, true);

--- a/test/testsets.json
+++ b/test/testsets.json
@@ -49,6 +49,7 @@
     { "name": "test_gpio_input.js", "skip": ["all"], "reason": "needs hardware" },
     { "name": "test_gpio_output.js", "skip": ["all"], "reason": "need user input"},
     { "name": "test_i2c.js", "skip": ["all"], "reason": "need to setup test environment" },
+    { "name": "test_iotjs_error_stack.js" },
     { "name": "test_iotjs_promise.js" },
     { "name": "test_iotjs_promise_chain_calls.js" },
     { "name": "test_module_cache.js", "skip": ["nuttx"], "reason": "not implemented for nuttx" },


### PR DESCRIPTION
Expected behavior:
```js
function namedFunction () {
  return new Error('foobar')
}

console.log(namedFunction())
// Error: foobar
//     at namedFunction (/some/where/the/script/locates.js:1:10)


function capturePlainObject () {
  var e = {}
  Error.captureStackTrace(e)
  return e
}

console.log(capturePlainObject().stack)
//     at capturePlainObject (/some/where/the/script/locates.js:10:10)
```


close #118 

