### PR TITLE
process: print the dlopen error correctly

### DIFF
--- a/src/modules/iotjs_module_process.c
+++ b/src/modules/iotjs_module_process.c
@@ -365,9 +365,9 @@ JS_FUNCTION(DLOpen) {
 
   void* handle = dlopen(iotjs_string_data(&location), RTLD_LAZY);
   if (handle == NULL) {
+    fprintf(stderr, "dlopen: error(%s)\n", error);
     return jerry_create_number(-1);
   }
-  dlerror(); // for clear dl errors.
 
   initfn = dlsym(handle, "iotjs_module_register");
   // check for dlsym

--- a/src/modules/iotjs_module_process.c
+++ b/src/modules/iotjs_module_process.c
@@ -365,7 +365,7 @@ JS_FUNCTION(DLOpen) {
 
   void* handle = dlopen(iotjs_string_data(&location), RTLD_LAZY);
   if (handle == NULL) {
-    fprintf(stderr, "dlopen: error(%s)\n", error);
+    fprintf(stderr, "dlopen: error(%s)\n", dlerror());
     return jerry_create_number(-1);
   }
 


### PR DESCRIPTION
Just prints the `dlerror` result correctly :)

/cc @Rokid/nodejs 