### PR TITLE
benchmark: add perf for buffer modules

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,6 +3,7 @@
 /samples/**
 /tools/**
 /test/**
+/benchmark/**
 /node_modules/**
 /src/js/ble*
 /src/js/iotjs.js

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,7 @@
+# Benchmark for ShadowNode
+
+Getting started with the following commands:
+
+```sh
+$ iotjs benchmark/run buffer
+```

--- a/benchmark/_cli.js
+++ b/benchmark/_cli.js
@@ -1,0 +1,103 @@
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+
+// Create an object of all benchmark scripts
+var benchmarks = {};
+fs.readdirSync(__dirname)
+  .filter(function(name) {
+    return fs.statSync(path.resolve(__dirname, name)).isDirectory();
+  })
+  .forEach(function(category) {
+    benchmarks[category] = fs.readdirSync(path.resolve(__dirname, category))
+      .filter((filename) => filename[0] !== '.' && filename[0] !== '_');
+  });
+
+function CLI(usage, settings) {
+  if (!(this instanceof CLI))
+    return new CLI(usage, settings);
+
+  if (process.argv.length < 3) {
+    this.abort(usage); // abort will exit the process
+  }
+
+  this.usage = usage;
+  this.optional = {};
+  this.items = [];
+
+  settings.arrayArgs.forEach((argName) => {
+    this.optional[argName] = [];
+  });
+
+  var currentOptional = null;
+  var mode = 'both'; // possible states are: [both, option, item]
+
+  process.argv.slice(2).forEach((arg) => {
+    if (arg === '--') {
+      // Only items can follow --
+      mode = 'item';
+    } else if (['both', 'option'].indexOf(mode) !== -1 && arg[0] === '-') {
+      // Optional arguments declaration
+
+      if (arg[1] === '-') {
+        currentOptional = arg.slice(2);
+      } else {
+        currentOptional = arg.slice(1);
+      }
+
+      if (settings.boolArgs && settings.boolArgs.indexOf(currentOptional) !== -1) {
+        this.optional[currentOptional] = true;
+        mode = 'both';
+      } else {
+        // expect the next value to be option related (either -- or the value)
+        mode = 'option';
+      }
+    } else if (mode === 'option') {
+      // Optional arguments value
+
+      if (settings.arrayArgs.indexOf(currentOptional) !== -1) {
+        this.optional[currentOptional].push(arg);
+      } else {
+        this.optional[currentOptional] = arg;
+      }
+
+      // the next value can be either an option or an item
+      mode = 'both';
+    } else if (['both', 'item'].indexOf(mode) !== -1) {
+      // item arguments
+      this.items.push(arg);
+
+      // the next value must be an item
+      mode = 'item';
+    } else {
+      // Bad case, abort
+      this.abort(usage);
+      return;
+    }
+  });
+}
+module.exports = CLI;
+
+CLI.prototype.abort = function(msg) {
+  console.error(msg);
+  process.exit(1);
+};
+
+CLI.prototype.benchmarks = function() {
+  var paths = [];
+  var filter = this.optional.filter || false;
+
+  this.items.forEach((category) => {
+    if (benchmarks[category] === undefined)
+      return;
+
+    benchmarks[category].forEach((scripts) => {
+      if (filter && scripts.lastIndexOf(filter) === -1)
+        return;
+      paths.push(path.join(category, scripts));
+    });
+  });
+
+  return paths;
+};

--- a/benchmark/buffer/buffer-base64-decode.js
+++ b/benchmark/buffer/buffer-base64-decode.js
@@ -1,0 +1,32 @@
+'use strict';
+var assert = require('assert');
+var common = require('../common.js');
+
+var bench = common.createBenchmark(main, {
+  size: [8 << 12],
+  n: [32],
+});
+
+function repeat(str, size) {
+  var r = '';
+  for (var i = 0; i < size; i++) {
+    r += str;
+  }
+  return r;
+}
+
+function main(opts) {
+  var size = opts.size;
+  var n = opts.n;
+  console.log(size, n);
+  var s = repeat('abcd', size);
+  // eslint-disable-next-line node-core/no-unescaped-regexp-dot
+  s.match(/./);  // Flatten string.
+  assert.strictEqual(s.length % 4, 0);
+  var b = Buffer.allocUnsafe(s.length / 4 * 3);
+  b.write(s, 0, s.length, 'base64');
+  bench.start();
+  for (var i = 0; i < n; i += 1)
+    b.write(s, 0, s.length, 'base64');
+  bench.end(n);
+}

--- a/benchmark/buffer/buffer-base64-encode.js
+++ b/benchmark/buffer/buffer-base64-encode.js
@@ -1,0 +1,24 @@
+'use strict';
+var common = require('../common.js');
+
+var bench = common.createBenchmark(main, {
+  len: [16 * 1024],
+  n: [32]
+});
+
+function main(opts) {
+  var len = opts.len;
+  var n = opts.n;
+  var b = Buffer.allocUnsafe(len);
+  var s = '';
+  var i;
+  for (i = 0; i < 256; ++i)
+    s += String.fromCharCode(i);
+  for (i = 0; i < len; i += 256) 
+    b.write(s, i, 256, 'ascii');
+  
+  bench.start();
+  for (i = 0; i < n; ++i)
+    b.toString('base64');
+  bench.end(n);
+}

--- a/benchmark/buffer/buffer-hex.js
+++ b/benchmark/buffer/buffer-hex.js
@@ -1,0 +1,25 @@
+'use strict';
+
+var common = require('../common.js');
+var bench = common.createBenchmark(main, {
+  len: [64],
+  n: [4 * 1024]
+});
+
+function main(opts) {
+  var len = opts.len;
+  var n = opts.n;
+  var buf = Buffer.alloc(len);
+  var i;
+
+  for (i = 0; i < buf.length; i++)
+    buf[i] = i & 0xff;
+
+  var hex = buf.toString('hex');
+  bench.start();
+
+  for (i = 0; i < n; i += 1)
+    Buffer.from(hex, 'hex');
+
+  bench.end(n);
+}

--- a/benchmark/buffer/buffer-tostring.js
+++ b/benchmark/buffer/buffer-tostring.js
@@ -1,0 +1,48 @@
+'use strict';
+
+var common = require('../common.js');
+var bench = common.createBenchmark(main, {
+  encoding: ['', 'utf8'],
+  args: [0, 1, 2, 3],
+  len: [0, 1, 64],
+  n: [1024]
+});
+
+function main(opts) {
+  var encoding = opts.encoding;
+  var args = opts.args;
+  var len = opts.len;
+  var n = opts.n;
+  var buf = Buffer.alloc(len, 42);
+
+  if (encoding.length === 0)
+    encoding = undefined;
+
+  var i;
+  switch (args) {
+    case 1:
+      bench.start();
+      for (i = 0; i < n; i += 1)
+        buf.toString(encoding);
+      bench.end(n);
+      break;
+    case 2:
+      bench.start();
+      for (i = 0; i < n; i += 1)
+        buf.toString(encoding, 0);
+      bench.end(n);
+      break;
+    case 3:
+      bench.start();
+      for (i = 0; i < n; i += 1)
+        buf.toString(encoding, 0, len);
+      bench.end(n);
+      break;
+    default:
+      bench.start();
+      for (i = 0; i < n; i += 1)
+        buf.toString();
+      bench.end(n);
+      break;
+  }
+}

--- a/benchmark/buffer/buffer-zero.js
+++ b/benchmark/buffer/buffer-zero.js
@@ -1,0 +1,22 @@
+'use strict';
+
+var common = require('../common.js');
+
+var bench = common.createBenchmark(main, {
+  n: [16],
+  type: ['buffer', 'string']
+});
+
+var zeroBuffer = Buffer.alloc(0);
+var zeroString = '';
+
+function main(opts) {
+  var n = opts.n;
+  var type = opts.type;
+  var data = type === 'buffer' ? zeroBuffer : zeroString;
+
+  bench.start();
+  for (var i = 0; i < n * 1024; i++)
+    Buffer.from(data);
+  bench.end(n);
+}

--- a/benchmark/common.js
+++ b/benchmark/common.js
@@ -1,0 +1,219 @@
+'use strict';
+
+var child_process = require('child_process');
+
+exports.createBenchmark = function(fn, configs, options) {
+  return new Benchmark(fn, configs, options);
+};
+
+function Benchmark(fn, configs, options) {
+  // Use the file name as the name of the benchmark
+  this.name = require.main.filename.slice(__dirname.length + 1);
+  // Parse job-specific configuration from the command line arguments
+  var parsed_args = this._parseArgs(process.argv.slice(2), configs);
+  this.options = parsed_args.cli;
+  this.extra_options = parsed_args.extra;
+  // The configuration list as a queue of jobs
+  this.queue = this._queue(this.options);
+  // The configuration of the current job, head of the queue
+  this.config = this.queue[0];
+  // Execution arguments i.e. flags used to run the jobs
+  this.flags = [];
+  if (options && options.flags) {
+    this.flags = this.flags.concat(options.flags);
+  }
+  // Holds process.hrtime value
+  this._time = [0, 0];
+  // Used to make sure a benchmark only start a timer once
+  this._started = false;
+
+  process.nextTick(() => fn(this.config));
+  // process.nextTick(this._run.bind(this));
+}
+
+Benchmark.prototype._parseArgs = function(argv, configs) {
+  var cliOptions = {};
+  var extraOptions = {};
+  var validArgRE = /^(.+?)=([\s\S]*)$/;
+  
+  // Parse configuration arguments
+  argv.forEach((arg) => {
+    var match = arg.match(validArgRE);
+    if (!match) {
+      console.error(`bad argument: ${arg}`);
+      return process.exit(1);
+    }
+    var config = match[1];
+
+    if (configs[config]) {
+      // Infer the type from the config object and parse accordingly
+      var isNumber = typeof configs[config][0] === 'number';
+      var value = isNumber ? +match[2] : match[2];
+      if (!cliOptions[config])
+        cliOptions[config] = [];
+      cliOptions[config].push(value);
+    } else {
+      extraOptions[config] = match[2];
+    }
+  });
+  return {
+    cli: Object.assign({}, configs, cliOptions),
+    extra: extraOptions
+  };
+};
+
+Benchmark.prototype._queue = function(options) {
+  var queue = [];
+  var keys = Object.keys(options);
+
+  // Perform a depth-first walk though all options to generate a
+  // configuration list that contains all combinations.
+  function recursive(keyIndex, prevConfig) {
+    var key = keys[keyIndex];
+    var values = options[key];
+    var type = typeof values[0];
+
+    values.forEach((value) => {
+      if (typeof value !== 'number' && typeof value !== 'string')
+        throw new TypeError(`configuration "${key}" had type ${typeof value}`);
+
+      if (typeof value !== type) {
+        // This is a requirement for being able to consistently and predictably
+        // parse CLI provided configuration values.
+        throw new TypeError(`configuration "${key}" has mixed types`);
+      }
+
+      var _config = {};
+      _config[key] = value;
+      var currConfig = Object.assign(_config, prevConfig);
+
+      if (keyIndex + 1 < keys.length) {
+        recursive(keyIndex + 1, currConfig);
+      } else {
+        queue.push(currConfig);
+      }
+    });
+  }
+
+  if (keys.length > 0) {
+    recursive(0, {});
+  } else {
+    queue.push({});
+  }
+
+  return queue;
+};
+
+Benchmark.prototype._run = function() {
+  var self = this;
+  // If forked, report to the parent.
+  if (process.send) {
+    process.send({
+      type: 'config',
+      name: this.name,
+      queueLength: this.queue.length
+    });
+  }
+
+  (function recursive(queueIndex) {
+    var config = self.queue[queueIndex];
+
+    // set NODE_RUN_BENCHMARK_FN to indicate that the child shouldn't construct
+    // a configuration queue, but just execute the benchmark function.
+    var childEnv = Object.assign({}, process.env);
+    childEnv.NODE_RUN_BENCHMARK_FN = '';
+
+    // Create configuration arguments
+    var childArgs = [];
+    Object.keys(config).forEach((key) => {
+      childArgs.push(`${key}=${config[key]}`);
+    });
+    Object.keys(self.extra_options).forEach((key) => {
+      childArgs.push(`${key}=${self.extra_options[key]}`);
+    });
+
+    var child = child_process.fork(require.main.filename, childArgs, {
+      env: childEnv,
+      execArgv: self.flags.concat(process.execArgv)
+    });
+    child.on('message', sendResult);
+    child.on('close', function(code) {
+      if (code) {
+        process.exit(code);
+        return;
+      }
+
+      if (queueIndex + 1 < self.queue.length) {
+        recursive(queueIndex + 1);
+      }
+    });
+  })(0);
+};
+
+Benchmark.prototype.start = function() {
+  if (this._started) {
+    throw new Error('Called start more than once in a single benchmark');
+  }
+  this._started = true;
+  this._time = process.hrtime();
+};
+
+Benchmark.prototype.end = function(operations) {
+  // get elapsed time now and do error checking later for accuracy.
+  var elapsed = process.hrtime(this._time);
+
+  if (!this._started) {
+    throw new Error('called end without start');
+  }
+  if (typeof operations !== 'number') {
+    throw new Error('called end() without specifying operation count');
+  }
+  if (!process.env.NODEJS_BENCHMARK_ZERO_ALLOWED && operations <= 0) {
+    throw new Error('called end() with operation count <= 0');
+  }
+  if (elapsed[0] === 0 && elapsed[1] === 0) {
+    if (!process.env.NODEJS_BENCHMARK_ZERO_ALLOWED)
+      throw new Error('insufficient clock precision for short benchmark');
+    // avoid dividing by zero
+    elapsed[1] = 1;
+  }
+
+  var time = elapsed[0] + elapsed[1] / 1e9;
+  var rate = operations / time;
+  this.report(rate, elapsed);
+};
+
+function formatResult(data) {
+  // Construct configuration string, " A=a, B=b, ..."
+  var conf = '';
+  Object.keys(data.conf).forEach((key) => {
+    conf += ` ${key}=${JSON.stringify(data.conf[key])}`;
+  });
+
+  var rate = data.rate.toString().split('.');
+  rate[0] = rate[0].replace(/(\d)(?=(?:\d\d\d)+(?!\d))/g, '$1,');
+  rate = (rate[1] ? rate.join('.') : rate[0]);
+  return `${data.name}${conf}: ${rate}`;
+}
+
+function sendResult(data) {
+  if (process.send) {
+    // If forked, report by process send
+    process.send(data);
+  } else {
+    // Otherwise report by stdout
+    console.log(formatResult(data));
+  }
+}
+exports.sendResult = sendResult;
+
+Benchmark.prototype.report = function(rate, elapsed) {
+  sendResult({
+    name: this.name,
+    conf: this.config,
+    rate: rate,
+    time: elapsed[0] + elapsed[1] / 1e9,
+    type: 'report'
+  });
+};
+

--- a/benchmark/run.js
+++ b/benchmark/run.js
@@ -1,0 +1,77 @@
+'use strict';
+
+var path = require('path');
+var fork = require('child_process').fork;
+var CLI = require('./_cli.js');
+
+var cli = CLI(`usage: iotjs run.js [options] [--] <category> ...
+  Run each benchmark in the <category> directory a single time, more than one
+  <category> directory can be specified.
+  --filter pattern          string to filter benchmark scripts
+  --set    variable=value   set benchmark variable (can be repeated)
+  --format [simple|csv]     optional value that specifies the output format
+`, { arrayArgs: ['set'] });
+var benchmarks = cli.benchmarks();
+
+if (benchmarks.length === 0) {
+  console.error('No benchmarks found');
+  process.exitCode = 1;
+  return;
+}
+
+var validFormats = ['csv', 'simple'];
+var format = cli.optional.format || 'simple';
+if (validFormats.indexOf(format) === -1) {
+  console.error('Invalid format detected');
+  process.exitCode = 1;
+  return;
+}
+
+if (format === 'csv') {
+  console.log('"filename", "configuration", "rate", "time"');
+}
+
+(function recursive(i) {
+  var filename = benchmarks[i];
+  var child = fork(path.resolve(__dirname, filename), cli.optional.set);
+
+  if (format !== 'csv') {
+    console.log();
+    console.log(filename);
+  }
+
+  child.on('message', function(data) {
+    if (data.type !== 'report') {
+      return;
+    }
+    // Construct configuration string, " A=a, B=b, ..."
+    var conf = '';
+    Object.keys(data.conf).forEach((key) => {
+      conf += ` ${key}=${JSON.stringify(data.conf[key])}`;
+    });
+    // delete first space of the configuration
+    conf = conf.slice(1);
+    if (format === 'csv') {
+      // Escape quotes (") for correct csv formatting
+      conf = conf.replace(/"/g, '""');
+      console.log(`"${data.name}", "${conf}", ${data.rate}, ${data.time}`);
+    } else {
+      var rate = data.rate.toString().split('.');
+      rate[0] = rate[0].replace(/(\d)(?=(?:\d\d\d)+(?!\d))/g, '$1,');
+      rate = (rate[1] ? rate.join('.') : rate[0]);
+      console.log(`${data.name} ${conf}: ${rate}`);
+    }
+  });
+
+  child.once('close', function(code) {
+    if (code) {
+      process.exit(code);
+      return;
+    }
+
+    // If there are more benchmarks execute the next
+    if (i + 1 < benchmarks.length) {
+      recursive(i + 1);
+    }
+  });
+})(0);

--- a/src/js/module.js
+++ b/src/js/module.js
@@ -33,6 +33,12 @@ iotjs_module_t.wrapper = Native.wrapper;
 iotjs_module_t.wrap = Native.wrap;
 iotjs_module_t.curr = null;
 
+var mainModule = {
+  id: '.',
+  exports: {},
+  parent: null,
+  filename: '',
+};
 
 var cwd;
 try {
@@ -251,9 +257,12 @@ iotjs_module_t.prototype.compile = function(snapshot) {
       throw new TypeError('Invalid snapshot file.');
   }
 
+  var _require = this.require.bind(this);
+  _require.main = mainModule;
+
   fn.apply(this.exports, [
     this.exports,             // exports
-    this.require.bind(this),  // require
+    _require,                 // require
     this,                     // module
     undefined,                // native
     __filename,               // __filename
@@ -276,7 +285,8 @@ iotjs_module_t.runMain = function() {
     var fn = process.debuggerSourceCompile();
     fn.call();
   } else {
-    iotjs_module_t.load(process.argv[1], null);
+    var filename = mainModule.filename = process.argv[1];
+    mainModule.exports = iotjs_module_t.load(filename, null);
   }
   while (process._onNextTick());
 };


### PR DESCRIPTION
Initialized the benchmark(copy from nodejs), and the results on my mac is:

```
buffer/buffer-base64-decode.js
32768 32
buffer/buffer-base64-decode.js n=32 size=32768: 2,353.614552516459

buffer/buffer-base64-encode.js
buffer/buffer-base64-encode.js n=32 len=16384: 1,780.9553979756324

buffer/buffer-hex.js
buffer/buffer-hex.js n=4096 len=64: 23,693.716692424714

buffer/buffer-tostring.js
buffer/buffer-tostring.js n=1024 len=0 args=0 encoding="": 196,401.02788319203

buffer/buffer-zero.js
buffer/buffer-zero.js type="buffer" n=16: 27.505013850295846
```

And the Node.js runs the same source code:

```
buffer/buffer-base64-decode.js
32768 32
buffer/buffer-base64-decode.js n=32 size=32768: 7,263.34764969419

buffer/buffer-base64-encode.js
buffer/buffer-base64-encode.js n=32 len=16384: 18,407.20181771118

buffer/buffer-hex.js
buffer/buffer-hex.js n=4096 len=64: 555,132.775806186

buffer/buffer-tostring.js
buffer/buffer-tostring.js n=1024 len=0 args=0 encoding="": 3,472,045.624849539

buffer/buffer-zero.js
buffer/buffer-zero.js type="buffer" n=16: 1,186.514080955856
```
