### PR TITLE
net: use ipv4 for dns family by default

### DIFF
--- a/src/js/net.js
+++ b/src/js/net.js
@@ -123,7 +123,7 @@ Socket.prototype.connect = function() {
   var host = options.host ? options.host : 'localhost';
   var port = Number(options.port);
   var dnsopts = {
-    family: options.family >>> 0,
+    family: (options.family || 4) >>> 0,
     hints: 0,
   };
 


### PR DESCRIPTION
If not specified, we use IPv4 as the default option, this is compatible with some routers which did not support IPv6.