### PR TITLE
console: optimize the log function for single param

### DIFF
--- a/benchmark/console/common.js
+++ b/benchmark/console/common.js
@@ -1,0 +1,16 @@
+'use strict';
+
+var common = require('../common.js');
+var bench = common.createBenchmark(main, {
+  n: [128],
+});
+
+function main(opts) {
+  var n = opts.n;
+
+  bench.start();
+  for (var i = 0; i < n; i += 1)
+    console.log('');
+
+  bench.end(n);
+}

--- a/benchmark/console/common.js
+++ b/benchmark/console/common.js
@@ -7,10 +7,8 @@ var bench = common.createBenchmark(main, {
 
 function main(opts) {
   var n = opts.n;
-
   bench.start();
   for (var i = 0; i < n; i += 1)
     console.log('');
-
   bench.end(n);
 }

--- a/src/js/console.js
+++ b/src/js/console.js
@@ -48,12 +48,20 @@ function stderr(text) {
 Console.prototype.log =
 Console.prototype.debug =
 Console.prototype.info = function() {
-  stdout(util.format.apply(this, arguments) + '\n');
+  if (arguments.length === 1) {
+    stdout(arguments[0] + '\n');
+  } else {
+    stdout(util.format.apply(this, arguments) + '\n');
+  }
 };
 
 Console.prototype.warn =
 Console.prototype.error = function() {
-  stderr(util.format.apply(this, arguments) + '\n');
+  if (arguments.length === 1) {
+    stderr(arguments[0] + '\n');
+  } else {
+    stderr(util.format.apply(this, arguments) + '\n');
+  }
 };
 
 Console.prototype.time = function(label) {


### PR DESCRIPTION
BTW, added the benchmark for `console.log`.

```sh
> console/common.js n=128: 22,295.029427697045   #before
> console/common.js n=128: 38,630.9784834504     #after
```

The performance under this case is optimized 57% up :)