### PR TITLE
http: set content-length if not set and body is set

### DIFF
--- a/src/js/http_outgoing.js
+++ b/src/js/http_outgoing.js
@@ -108,7 +108,10 @@ OutgoingMessage.prototype._send = function(chunk, encoding, callback) {
     chunk = chunk.toString();
   }
   this._bodyLength += chunk.length;
-  if (!this.getHeader('Content-Length') && this._bodyLength) {
+  if (!this.getHeader('Content-Length') &&
+    // 'chunked' transfer-encoding should not set content-length
+    this.getHeader('Transfer-Encoding') !== 'chunked' &&
+    this._bodyLength) {
     this.setHeader('Content-Length', this._bodyLength);
   }
 

--- a/src/js/http_outgoing.js
+++ b/src/js/http_outgoing.js
@@ -24,6 +24,7 @@ function OutgoingMessage() {
   this.writable = true;
 
   this._hasBody = true;
+  this._bodyLength = 0;
 
   this.finished = false;
   this._sentHeader = false;
@@ -106,6 +107,10 @@ OutgoingMessage.prototype._send = function(chunk, encoding, callback) {
   if (util.isBuffer(chunk)) {
     chunk = chunk.toString();
   }
+  this._bodyLength += chunk.length;
+  if (!this.getHeader('Content-Length') && this._bodyLength) {
+    this.setHeader('Content-Length', this._bodyLength);
+  }
 
   if (!this._sentHeader) {
     chunk = this._header + '\r\n' + chunk;
@@ -177,7 +182,12 @@ OutgoingMessage.prototype.removeHeader = function(name) {
 
 
 OutgoingMessage.prototype.getHeader = function(name) {
-  return this._headers[name];
+  return this._headers[name.toLowerCase()];
+};
+
+
+OutgoingMessage.prototype.getHeaders = function() {
+  return this._headers;
 };
 
 

--- a/test/run_pass/test_net_http_request_response.js
+++ b/test/run_pass/test_net_http_request_response.js
@@ -241,6 +241,30 @@ request8.on('response', function(incomingMessage) {
 });
 
 
+// Test the content-length not set if chunked
+var server9 = http.createServer(function(request, response) {
+  request.on('end', function() {
+    response.end('ok');
+    server9.close();
+  });
+}).listen(3012);
+
+var isRequest9Finished = false;
+var request9 = http.request({
+  host: '127.0.0.1',
+  port: 3012,
+  path: '/',
+  method: 'POST'
+});
+request9.setHeader('Transfer-Encoding', 'chunked');
+request9.end('foobar');
+request9.on('response', function(incomingMessage) {
+  assert.equal(incomingMessage.statusCode, 200);
+  assert.equal(request9.getHeader('content-length'), undefined);
+  isRequest9Finished = true;
+});
+
+
 process.on('exit', function() {
   assert.equal(isRequest1Finished, true);
   assert.equal(isRequest2Finished, true);
@@ -249,4 +273,5 @@ process.on('exit', function() {
   assert.equal(isRequest5Finished, true);
   assert.equal(isRequest7Finished, true);
   assert.equal(isRequest8Finished, true);
+  assert.equal(isRequest9Finished, true);
 });

--- a/test/run_pass/test_net_http_request_response.js
+++ b/test/run_pass/test_net_http_request_response.js
@@ -194,10 +194,59 @@ readRequest.on('response', function(incomingMessage) {
 });
 
 
+// Test the content length
+var server7 = http.createServer(function(request, response) {
+  request.on('end', function() {
+    response.end('ok');
+    server7.close();
+  });
+}).listen(3010);
+
+var isRequest7Finished = false;
+var readRequest = http.request({
+  host: '127.0.0.1',
+  port: 3010,
+  path: '/',
+  method: 'POST'
+});
+readRequest.end('foobar');
+readRequest.on('response', function(incomingMessage) {
+  assert.equal(incomingMessage.statusCode, 200);
+  assert.equal(readRequest.getHeader('content-length'), 6);
+  isRequest7Finished = true;
+});
+
+
+// Test the content length if set content-length
+var server8 = http.createServer(function(request, response) {
+  request.on('end', function() {
+    response.end('ok');
+    server8.close();
+  });
+}).listen(3011);
+
+var isRequest8Finished = false;
+var request8 = http.request({
+  host: '127.0.0.1',
+  port: 3011,
+  path: '/',
+  method: 'POST'
+});
+request8.setHeader('Content-Length', 10);
+request8.end('foobar');
+request8.on('response', function(incomingMessage) {
+  assert.equal(incomingMessage.statusCode, 200);
+  assert.equal(request8.getHeader('content-length'), 10);
+  isRequest8Finished = true;
+});
+
+
 process.on('exit', function() {
   assert.equal(isRequest1Finished, true);
   assert.equal(isRequest2Finished, true);
   assert.equal(isRequest3Finished, true);
   assert.equal(isRequest4Finished, true);
   assert.equal(isRequest5Finished, true);
+  assert.equal(isRequest7Finished, true);
+  assert.equal(isRequest8Finished, true);
 });


### PR DESCRIPTION
This fixes #102, now we have http/https is to set `Content-Length` by default if body is present. 

/cc @legendecas @lolBig