### PR TITLE
iotjs: check if uv_handle is valid for handlewrap safely

### DIFF
--- a/src/iotjs.c
+++ b/src/iotjs.c
@@ -179,10 +179,14 @@ static int iotjs_start(iotjs_environment_t* env) {
 
 
 static void iotjs_uv_walk_to_close_callback(uv_handle_t* handle, void* arg) {
-  iotjs_handlewrap_t* handle_wrap = iotjs_handlewrap_from_handle(handle);
-  IOTJS_ASSERT(handle_wrap != NULL);
-
-  iotjs_handlewrap_close(handle_wrap, NULL);
+  iotjs_handlewrap_t* handlewrap = iotjs_handlewrap_from_handle_unsafe(handle);
+  if (iotjs_handlewrap_validate_with_result(handlewrap)) {
+    iotjs_handlewrap_validate(handlewrap);
+    IOTJS_ASSERT(handlewrap != NULL);
+    iotjs_handlewrap_close(handlewrap, NULL);
+  } else if (uv_is_closing(handle) == 0) {
+    uv_close(handle, NULL);
+  }
 }
 
 static jerry_value_t dummy_wait_for_client_source_cb() {

--- a/src/iotjs_handlewrap.c
+++ b/src/iotjs_handlewrap.c
@@ -53,6 +53,12 @@ iotjs_handlewrap_t* iotjs_handlewrap_from_handle(uv_handle_t* handle) {
 }
 
 
+iotjs_handlewrap_t* iotjs_handlewrap_from_handle_unsafe(uv_handle_t* handle) {
+  iotjs_handlewrap_t* handlewrap = (iotjs_handlewrap_t*)(handle->data);
+  return handlewrap;
+}
+
+
 iotjs_handlewrap_t* iotjs_handlewrap_from_jobject(jerry_value_t jobject) {
   iotjs_handlewrap_t* handlewrap =
       (iotjs_handlewrap_t*)(iotjs_jval_get_object_native_handle(jobject));
@@ -122,4 +128,12 @@ void iotjs_handlewrap_validate(iotjs_handlewrap_t* handlewrap) {
   IOTJS_ASSERT((uintptr_t)_this ==
                iotjs_jval_get_object_native_handle(
                    iotjs_jobjectwrap_jobject(&_this->jobjectwrap)));
+}
+
+
+bool iotjs_handlewrap_validate_with_result(iotjs_handlewrap_t* handlewrap) {
+  if (handlewrap->flag_create != IOTJS_VALID_MAGIC_SEQUENCE) {
+    return false;
+  }
+  return true;
 }

--- a/src/iotjs_handlewrap.h
+++ b/src/iotjs_handlewrap.h
@@ -60,12 +60,13 @@ void iotjs_handlewrap_close(iotjs_handlewrap_t* handlewrap,
                             OnCloseHandler on_close_cb);
 
 iotjs_handlewrap_t* iotjs_handlewrap_from_handle(uv_handle_t* handle);
+iotjs_handlewrap_t* iotjs_handlewrap_from_handle_unsafe(uv_handle_t* handle);
 iotjs_handlewrap_t* iotjs_handlewrap_from_jobject(jerry_value_t jobject);
 
 uv_handle_t* iotjs_handlewrap_get_uv_handle(iotjs_handlewrap_t* handlewrap);
 jerry_value_t iotjs_handlewrap_jobject(iotjs_handlewrap_t* handlewrap);
 
 void iotjs_handlewrap_validate(iotjs_handlewrap_t* handlewrap);
-
+bool iotjs_handlewrap_validate_with_result(iotjs_handlewrap_t* handlewrap);
 
 #endif /* IOTJS_HANDLEWRAP_H */


### PR DESCRIPTION
This should fixes #143

Just check the handle data's flag, if not a handlewarp, just
directly close the handle.

/cc @lolBig @algebrait 