### PR TITLE
stack: should print error.stack when not catching uncaughtException

### DIFF
--- a/deps/jerry/jerry-core/api/jerry.c
+++ b/deps/jerry/jerry-core/api/jerry.c
@@ -3404,7 +3404,7 @@ bool
 jerry_set_parser_dump_file (char *path)
 {
   jerry_assert_api_available ();
-  JERRY_CONTEXT (parser_dump_fd) = fopen(path, "a+");
+  JERRY_CONTEXT (parser_dump_fd) = fopen (path, "a+");
   return true;
 }
 

--- a/src/js/iotjs.js
+++ b/src/js/iotjs.js
@@ -50,9 +50,12 @@
   function loadDumpIfExists() {
     var lines = [];
     try {
+      process._flushParserDumpFile();
       var loc = '/tmp/iotjs.' + process.pid;
       lines = fs.readFileSync(loc).toString().split('\n');
-    } catch (err) {}
+    } catch (err) {
+      console.error(`occurrs unkwnown error when loading dump: ${err.message}`);
+    }
     return lines;
   }
 
@@ -109,7 +112,7 @@
       }
     } else {
       // Exit if there are no handler for uncaught exception.
-      console.error(error);
+      console.error(error && error.stack);
       process.exit(1);
     }
   }
@@ -203,8 +206,8 @@
       enumerable: false,
       get: function() {
         if (this.__stack__ === undefined) {
-          process._flushParserDumpFile();
-          this.__stack__ = makeStackTraceFromDump(this.__frames__ || []);
+          this.__stack__ = `Error: ${this.message}\n`
+            + makeStackTraceFromDump(this.__frames__ || []);
         }
         return this.__stack__;
       },

--- a/src/js/iotjs.js
+++ b/src/js/iotjs.js
@@ -206,7 +206,7 @@
       enumerable: false,
       get: function() {
         if (this.__stack__ === undefined) {
-          this.__stack__ = `Error: ${this.message}\n`
+          this.__stack__ = `${this.name || 'Error'}: ${this.message}\n`
             + makeStackTraceFromDump(this.__frames__ || []);
         }
         return this.__stack__;


### PR DESCRIPTION
We should use `error.stack` as the outputs when not catching `uncaughtException`, and add the message line in front of `.stack`.