### PR TITLE
net: check if shutdown is a function.

### DIFF
--- a/src/js/net.js
+++ b/src/js/net.js
@@ -518,7 +518,9 @@ function onSocketFinish() {
   var self = this;
   var state = self._socketState;
 
-  if (!state.readable || self._readableState.ended || !self._handle) {
+  if (!state.readable || self._readableState.ended 
+    || !self._handle
+    || typeof self._handle.shutdown !== 'function') {
     // no readable stream or ended, destroy(close) socket.
     return self.destroy();
   } else {

--- a/src/js/net.js
+++ b/src/js/net.js
@@ -518,9 +518,9 @@ function onSocketFinish() {
   var self = this;
   var state = self._socketState;
 
-  if (!state.readable || self._readableState.ended 
-    || !self._handle
-    || typeof self._handle.shutdown !== 'function') {
+  if (!state.readable ||
+    self._readableState.ended ||
+    !self._handle || typeof self._handle.shutdown !== 'function') {
     // no readable stream or ended, destroy(close) socket.
     return self.destroy();
   } else {

--- a/test/run_pass/test_net_end.js
+++ b/test/run_pass/test_net_end.js
@@ -1,0 +1,10 @@
+'use strict';
+
+var net = require('net');
+var Pipe = require('pipe_wrap').Pipe;
+
+var handle = new Pipe();
+handle.open(0);
+
+var socket = new net.Socket({ handle: handle });
+socket.end();

--- a/test/testsets.json
+++ b/test/testsets.json
@@ -66,6 +66,7 @@
     { "name": "test_net_9.js" },
     { "name": "test_net_10.js" },
     { "name": "test_net_connect.js" },
+    { "name": "test_net_end.js" },
     { "name": "test_net_headers.js" },
     { "name": "test_net_http_get.js" },
     { "name": "test_net_http_response_twice.js" },


### PR DESCRIPTION
Pipe doesn't own `shutdown` function, which causes crash when the writable is finished.

Fixes #150