### PR TITLE
iotjs: fix the compile failure when release build

### DIFF
--- a/src/iotjs_handlewrap.c
+++ b/src/iotjs_handlewrap.c
@@ -132,8 +132,14 @@ void iotjs_handlewrap_validate(iotjs_handlewrap_t* handlewrap) {
 
 
 bool iotjs_handlewrap_validate_with_result(iotjs_handlewrap_t* handlewrap) {
+#ifdef NDEBUG
+  if (&handlewrap->unsafe == NULL) {
+    return false;
+  }
+#else
   if (handlewrap->flag_create != IOTJS_VALID_MAGIC_SEQUENCE) {
     return false;
   }
+#endif
   return true;
 }


### PR DESCRIPTION

In `Release` build doesn't has the `flag_create` option, we should find another way to validate if it is handwrap.