### PR TITLE
http: allow zero value for content-length by correct check for value

### DIFF
--- a/src/js/http_outgoing.js
+++ b/src/js/http_outgoing.js
@@ -163,7 +163,7 @@ OutgoingMessage.prototype.setHeader = function(name, value) {
     throw new TypeError('Name must be string.');
   }
 
-  if (!value && value !== '') {
+  if (util.isNullOrUndefined(value)) {
     throw new Error('value required in setHeader(' + name + ', value)');
   }
 

--- a/test/run_pass/test_net_headers.js
+++ b/test/run_pass/test_net_headers.js
@@ -51,6 +51,7 @@ var server = http.createServer(function(req, res) {
     for (var i = 0; i < responseSize; i++) {
       res.setHeader('h' + (5 + i), 'h' + (5 + i));
     }
+    res.setHeader('content-length', 0);
 
     res.end(function() {
       server.close();
@@ -78,6 +79,7 @@ var postResponseHandler = function(res) {
   assert.equal(res.headers.h1, 'h1');
   assert.equal(res.headers.h2, undefined);
   assert.equal(res.headers.h3, 'h3prime');
+  assert.equal(res.headers['content-length'], 0);
 
   var endHandler = function() {
     checkReqFinish = true;


### PR DESCRIPTION
Allow the following:

```js
res.setHeader('content-length', 0);
```