### PR TITLE
buffer: add writeInt32LE impl and docs

### DIFF
--- a/docs/api/Buffer.md
+++ b/docs/api/Buffer.md
@@ -1,24 +1,5 @@
 ### Platform Support
 
-The following shows Buffer module APIs available for each platform.
-
-|  | Linux<br/>(Ubuntu) | Raspbian<br/>(Raspberry Pi) | NuttX<br/>(STM32F4-Discovery) | TizenRT<br/>(Artik053) |
-| :---: | :---: | :---: | :---: | :---: |
-| buf.compare | O | O | O | O |
-| buf.copy | O | O | O | O |
-| buf.equals | O | O | O | O |
-| buf.fill | O | O | O | O |
-| buf.slice | O | O | O | O |
-| buf.toString | O | O | O | O |
-| buf.write | O | O | O | O |
-| buf.writeUInt8 | O | O | O | O |
-| buf.writeUInt16LE | O | O | O | O |
-| buf.writeUInt32LE | O | O | O | O |
-| buf.readInt8 | O | O | O | O |
-| buf.readUInt8 | O | O | O | O |
-| buf.readUInt16LE | O | O | O | O |
-
-
 # Buffer
 
 Buffer class is a global type with various constructors and accessors.
@@ -420,6 +401,18 @@ buffer.write('ABCDEF', 1, 3);
 // prints: .ABC..
 console.log(buffer);
 ```
+
+
+### buf.writeInt32(value, offset[, noAssert])
+* `value` {integer} Number to be written into the buffer.
+* `offset` {integer} Start position of the writing.
+* `noAssert` {boolean} Skip argument validation. **Default:** `false`
+* Returns: {number} Offset plus the number of bytes written.
+
+Writes `value` to `buf` at the specified `offset` with specified endian
+format (`writeInt32BE()` writes big endian, `writeInt32LE()` writes little 
+endian). `value` should be a valid signed 32-bit integer. Behavior is 
+undefined when `value` is anything other than a signed 32-bit integer.
 
 
 ### buf.writeUInt8(value, offset[, noAssert])

--- a/src/js/buffer.js
+++ b/src/js/buffer.js
@@ -302,6 +302,22 @@ Buffer.prototype.writeUInt32LE = function(value, offset, noAssert) {
 };
 
 
+// buff.writeInt32LE(value, offset[,noAssert])
+// [1] buff.writeInt32LE(value, offset)
+// [2] buff.writeInt32LE(value, offset, noAssert)
+Buffer.prototype.writeInt32LE = function(value, offset, noAssert) {
+  value = +value;
+  offset = offset >>> 0;
+  if (!noAssert)
+    checkInt(this, value, offset, 4, 0x7fffffff, -0x80000000);
+  this._builtin.writeUInt8(value & 0xff, offset);
+  this._builtin.writeUInt8((value >>> 8) & 0xff, offset + 1);
+  this._builtin.writeUInt8((value >>> 16) & 0xff, offset + 2);
+  this._builtin.writeUInt8((value >>> 24) & 0xff, offset + 3);
+  return offset + 4;
+};
+
+
 // buff.readUInt8(offset[,noAssert])
 // [1] buff.readUInt8(offset)
 // [2] buff.readUInt8(offset, noAssert)

--- a/test/run_pass/test_buffer.js
+++ b/test/run_pass/test_buffer.js
@@ -83,6 +83,7 @@ buff_5.readInt8(3, true);
 buff_5.writeUInt32LE(0, 0, true);
 buff_5.writeUInt8(0, 0, true);
 buff_5.writeUInt16LE(0, 0, true);
+buff_5.writeInt32LE(0, 0, true);
 
 
 var buff6 = buff3.slice(1);
@@ -130,10 +131,12 @@ assert.equal(buff3.toString(), 'testabcdefgh');
 var buff13 = new Buffer(4);
 buff13.writeUInt8(0x11, 0);
 assert.equal(buff13.readUInt8(0), 0x11);
+
 buff13.writeUInt16LE(0x3456, 1);
 assert.equal(buff13.readUInt8(1), 0x56);
 assert.equal(buff13.readUInt8(2), 0x34);
 assert.equal(buff13.readUInt16LE(1), 0x3456);
+
 buff13.writeUInt32LE(0x89abcdef, 0);
 assert.equal(buff13.readUInt8(0), 0xef);
 assert.equal(buff13.readUInt8(1), 0xcd);
@@ -142,6 +145,17 @@ assert.equal(buff13.readUInt8(3), 0x89);
 assert.equal(buff13.readUInt16LE(0), 0xcdef);
 assert.equal(buff13.readUInt16LE(2), 0x89ab);
 
+buff13.writeInt32LE(0x7fabcdef, 0);
+assert.equal(buff13.readUInt8(0), 0xef);
+assert.equal(buff13.readInt8(0), -17);
+assert.equal(buff13.readUInt8(1), 0xcd);
+assert.equal(buff13.readInt8(1), -51);
+assert.equal(buff13.readUInt8(2), 0xab);
+assert.equal(buff13.readInt8(2), -85);
+assert.equal(buff13.readInt8(3), 0x7f);
+assert.equal(buff13.readUInt16LE(0), 0xcdef);
+assert.equal(buff13.readInt16LE(0), -12817);
+assert.equal(buff13.readInt16LE(2), 0x7fab);
 
 var buff14 = new Buffer([0x01, 0xa1, 0xfb]);
 assert.equal(buff14.readUInt8(0), 0x01);


### PR DESCRIPTION
Implements the function `buffer.writeInt32LE()` which [Rokid/node-turen](https://github.com/Rokid/node-turen) depends on it.

/cc @legendecas @LanFly 