### PR TITLE
 iotjs, env: add handlewrap_queue for clean it more clear

### DIFF
--- a/src/iotjs.c
+++ b/src/iotjs.c
@@ -180,14 +180,8 @@ static int iotjs_start(iotjs_environment_t* env) {
 }
 
 static void iotjs_uv_walk_to_close_callback(uv_handle_t* handle, void* arg) {
-  iotjs_handlewrap_t* handlewrap = iotjs_handlewrap_from_handle_unsafe(handle);
-  if (iotjs_handlewrap_validate_with_result(handlewrap)) {
-    iotjs_handlewrap_validate(handlewrap);
-    IOTJS_ASSERT(handlewrap != NULL);
-    iotjs_handlewrap_close(handlewrap, NULL);
-  } else if (uv_is_closing(handle) == 0) {
+  if (!uv_is_closing(handle))
     uv_close(handle, NULL);
-  }
 }
 
 static jerry_value_t dummy_wait_for_client_source_cb() {
@@ -262,6 +256,9 @@ int iotjs_entry(int argc, char** argv) {
 
   // Start iot.js.
   ret_code = iotjs_start(env);
+
+  // Cleanup handlewraps by handlewrap_queue
+  iotjs_environment_cleanup_handlewrap();
 
   // Close uv loop.
   uv_walk(iotjs_environment_loop(env), iotjs_uv_walk_to_close_callback, NULL);

--- a/src/iotjs_env.c
+++ b/src/iotjs_env.c
@@ -213,7 +213,8 @@ void iotjs_environment_remove_handlewrap(void* handlewrap) {
   const iotjs_environment_t* env = iotjs_environment_get();
   const IOTJS_VALIDATED_STRUCT_METHOD(iotjs_environment_t, env);
   list_node_t* node = list_find(_this->handlewrap_queue, handlewrap);
-  list_remove(_this->handlewrap_queue, node);
+  if (node != NULL)
+    list_remove(_this->handlewrap_queue, node);
 }
 
 
@@ -225,8 +226,10 @@ void iotjs_environment_cleanup_handlewrap() {
   list_iterator_t* it = list_iterator_new(_this->handlewrap_queue, LIST_HEAD);
   while ((node = list_iterator_next(it))) {
     iotjs_handlewrap_t* handlewrap = (iotjs_handlewrap_t*)(node->val);
-    iotjs_handlewrap_validate(handlewrap);
-    iotjs_handlewrap_close(handlewrap, NULL);
+    if (handlewrap != NULL) {
+      iotjs_handlewrap_validate(handlewrap);
+      iotjs_handlewrap_close(handlewrap, NULL);
+    }
   }
   list_iterator_destroy(it);
 }

--- a/src/iotjs_env.c
+++ b/src/iotjs_env.c
@@ -87,7 +87,7 @@ static void iotjs_environment_destroy(iotjs_environment_t* env) {
   IOTJS_VALIDATED_STRUCT_DESTRUCTOR(iotjs_environment_t, env);
   if (_this->handlewrap_queue != NULL)
     list_destroy(_this->handlewrap_queue);
-  
+
   if (_this->argv) {
     // release command line argument strings.
     // _argv[0] and _argv[1] refer addresses in static memory space.

--- a/src/iotjs_env.c
+++ b/src/iotjs_env.c
@@ -16,6 +16,7 @@
 
 #include "iotjs_def.h"
 #include "iotjs_env.h"
+#include "iotjs_handlewrap.h"
 
 #include <string.h>
 
@@ -72,6 +73,7 @@ static void iotjs_environment_initialize(iotjs_environment_t* env) {
   _this->argv = NULL;
   _this->loop = NULL;
   _this->state = kInitializing;
+  _this->handlewrap_queue = list_new();
   _this->config.memstat = false;
   _this->config.show_opcode = false;
   _this->config.debugger = NULL;
@@ -83,6 +85,9 @@ static void iotjs_environment_initialize(iotjs_environment_t* env) {
  */
 static void iotjs_environment_destroy(iotjs_environment_t* env) {
   IOTJS_VALIDATED_STRUCT_DESTRUCTOR(iotjs_environment_t, env);
+  if (_this->handlewrap_queue != NULL)
+    list_destroy(_this->handlewrap_queue);
+  
   if (_this->argv) {
     // release command line argument strings.
     // _argv[0] and _argv[1] refer addresses in static memory space.
@@ -194,6 +199,36 @@ void iotjs_environment_set_loop(iotjs_environment_t* env, uv_loop_t* loop) {
 const Config* iotjs_environment_config(const iotjs_environment_t* env) {
   const IOTJS_VALIDATED_STRUCT_METHOD(iotjs_environment_t, env);
   return &_this->config;
+}
+
+
+void iotjs_environment_create_handlewrap(void* handlewrap) {
+  const iotjs_environment_t* env = iotjs_environment_get();
+  const IOTJS_VALIDATED_STRUCT_METHOD(iotjs_environment_t, env);
+  list_rpush(_this->handlewrap_queue, list_node_new(handlewrap));
+}
+
+
+void iotjs_environment_remove_handlewrap(void* handlewrap) {
+  const iotjs_environment_t* env = iotjs_environment_get();
+  const IOTJS_VALIDATED_STRUCT_METHOD(iotjs_environment_t, env);
+  list_node_t* node = list_find(_this->handlewrap_queue, handlewrap);
+  list_remove(_this->handlewrap_queue, node);
+}
+
+
+void iotjs_environment_cleanup_handlewrap() {
+  const iotjs_environment_t* env = iotjs_environment_get();
+  const IOTJS_VALIDATED_STRUCT_METHOD(iotjs_environment_t, env);
+
+  list_node_t* node;
+  list_iterator_t* it = list_iterator_new(_this->handlewrap_queue, LIST_HEAD);
+  while ((node = list_iterator_next(it))) {
+    iotjs_handlewrap_t* handlewrap = (iotjs_handlewrap_t*)(node->val);
+    iotjs_handlewrap_validate(handlewrap);
+    iotjs_handlewrap_close(handlewrap, NULL);
+  }
+  list_iterator_destroy(it);
 }
 
 

--- a/src/iotjs_env.h
+++ b/src/iotjs_env.h
@@ -16,8 +16,8 @@
 #ifndef IOTJS_ENV_H
 #define IOTJS_ENV_H
 
-#include "uv.h"
 #include "iotjs_list.h"
+#include "uv.h"
 
 typedef struct {
   bool wait_source;

--- a/src/iotjs_env.h
+++ b/src/iotjs_env.h
@@ -31,13 +31,17 @@ typedef struct {
   DebuggerConfig* debugger;
 } Config;
 
+typedef struct {
+  iotjs_handlewrap_t** handles;
+  uint32_t size;
+} HandleQueue;
+
 typedef enum {
   kInitializing,
   kRunningMain,
   kRunningLoop,
   kExiting,
 } State;
-
 
 typedef struct {
   // Number of application arguments including 'iotjs' and app name.
@@ -54,6 +58,10 @@ typedef struct {
 
   // Run config
   Config config;
+
+  // handles
+  HandleQueue handle_queue;
+
 } IOTJS_VALIDATED_STRUCT(iotjs_environment_t);
 
 

--- a/src/iotjs_env.h
+++ b/src/iotjs_env.h
@@ -17,6 +17,7 @@
 #define IOTJS_ENV_H
 
 #include "uv.h"
+#include "iotjs_list.h"
 
 typedef struct {
   bool wait_source;
@@ -30,11 +31,6 @@ typedef struct {
   bool show_opcode;
   DebuggerConfig* debugger;
 } Config;
-
-typedef struct {
-  iotjs_handlewrap_t** handles;
-  uint32_t size;
-} HandleQueue;
 
 typedef enum {
   kInitializing,
@@ -53,14 +49,14 @@ typedef struct {
   // I/O event loop.
   uv_loop_t* loop;
 
+  // store all handlewrap objects
+  list_t* handlewrap_queue;
+
   // Running state.
   State state;
 
   // Run config
   Config config;
-
-  // handles
-  HandleQueue handle_queue;
 
 } IOTJS_VALIDATED_STRUCT(iotjs_environment_t);
 
@@ -80,6 +76,10 @@ void iotjs_environment_set_loop(iotjs_environment_t* env, uv_loop_t* loop);
 
 const Config* iotjs_environment_config(const iotjs_environment_t* env);
 const DebuggerConfig* iotjs_environment_dconfig(const iotjs_environment_t* env);
+
+void iotjs_environment_create_handlewrap(void* handlewrap);
+void iotjs_environment_remove_handlewrap(void* handlewrap);
+void iotjs_environment_cleanup_handlewrap();
 
 void iotjs_environment_go_state_running_main(iotjs_environment_t* env);
 void iotjs_environment_go_state_running_loop(iotjs_environment_t* env);

--- a/src/iotjs_handlewrap.c
+++ b/src/iotjs_handlewrap.c
@@ -55,12 +55,6 @@ iotjs_handlewrap_t* iotjs_handlewrap_from_handle(uv_handle_t* handle) {
 }
 
 
-iotjs_handlewrap_t* iotjs_handlewrap_from_handle_unsafe(uv_handle_t* handle) {
-  iotjs_handlewrap_t* handlewrap = (iotjs_handlewrap_t*)(handle->data);
-  return handlewrap;
-}
-
-
 iotjs_handlewrap_t* iotjs_handlewrap_from_jobject(jerry_value_t jobject) {
   iotjs_handlewrap_t* handlewrap =
       (iotjs_handlewrap_t*)(iotjs_jval_get_object_native_handle(jobject));
@@ -130,18 +124,4 @@ void iotjs_handlewrap_validate(iotjs_handlewrap_t* handlewrap) {
   IOTJS_ASSERT((uintptr_t)_this ==
                iotjs_jval_get_object_native_handle(
                    iotjs_jobjectwrap_jobject(&_this->jobjectwrap)));
-}
-
-
-bool iotjs_handlewrap_validate_with_result(iotjs_handlewrap_t* handlewrap) {
-#ifdef NDEBUG
-  if (&handlewrap->unsafe == NULL) {
-    return false;
-  }
-#else
-  if (handlewrap->flag_create != IOTJS_VALID_MAGIC_SEQUENCE) {
-    return false;
-  }
-#endif
-  return true;
 }

--- a/src/iotjs_handlewrap.c
+++ b/src/iotjs_handlewrap.c
@@ -14,8 +14,8 @@
  */
 
 #include "iotjs_def.h"
-#include "iotjs_env.h"
 #include "iotjs_handlewrap.h"
+#include "iotjs_env.h"
 
 
 void iotjs_handlewrap_initialize(iotjs_handlewrap_t* handlewrap,

--- a/src/iotjs_handlewrap.c
+++ b/src/iotjs_handlewrap.c
@@ -120,7 +120,9 @@ void iotjs_handlewrap_validate(iotjs_handlewrap_t* handlewrap) {
 
   IOTJS_ASSERT((iotjs_handlewrap_t*)_this == handlewrap);
   IOTJS_ASSERT((iotjs_jobjectwrap_t*)_this == &_this->jobjectwrap);
-  IOTJS_ASSERT((void*)_this == _this->handle->data);
+
+  if (_this->handle != NULL)
+    IOTJS_ASSERT((void*)_this == _this->handle->data);
   IOTJS_ASSERT((uintptr_t)_this ==
                iotjs_jval_get_object_native_handle(
                    iotjs_jobjectwrap_jobject(&_this->jobjectwrap)));

--- a/src/iotjs_handlewrap.c
+++ b/src/iotjs_handlewrap.c
@@ -14,6 +14,7 @@
  */
 
 #include "iotjs_def.h"
+#include "iotjs_env.h"
 #include "iotjs_handlewrap.h"
 
 
@@ -29,10 +30,10 @@ void iotjs_handlewrap_initialize(iotjs_handlewrap_t* handlewrap,
 
   _this->handle = handle;
   _this->on_close_cb = NULL;
-
   handle->data = handlewrap;
 
   iotjs_handlewrap_validate(handlewrap);
+  iotjs_environment_create_handlewrap(handlewrap);
 }
 
 
@@ -42,6 +43,7 @@ void iotjs_handlewrap_destroy(iotjs_handlewrap_t* handlewrap) {
   // Handle should have been release before this.
   IOTJS_ASSERT(_this->handle == NULL);
 
+  iotjs_environment_remove_handlewrap(handlewrap);
   iotjs_jobjectwrap_destroy(&_this->jobjectwrap);
 }
 

--- a/src/iotjs_handlewrap.h
+++ b/src/iotjs_handlewrap.h
@@ -18,7 +18,6 @@
 
 
 #include <uv.h>
-
 #include "iotjs_binding.h"
 #include "iotjs_objectwrap.h"
 

--- a/src/iotjs_handlewrap.h
+++ b/src/iotjs_handlewrap.h
@@ -18,6 +18,7 @@
 
 
 #include <uv.h>
+#include "iotjs_list.h"
 #include "iotjs_binding.h"
 #include "iotjs_objectwrap.h"
 

--- a/src/iotjs_handlewrap.h
+++ b/src/iotjs_handlewrap.h
@@ -60,13 +60,11 @@ void iotjs_handlewrap_close(iotjs_handlewrap_t* handlewrap,
                             OnCloseHandler on_close_cb);
 
 iotjs_handlewrap_t* iotjs_handlewrap_from_handle(uv_handle_t* handle);
-iotjs_handlewrap_t* iotjs_handlewrap_from_handle_unsafe(uv_handle_t* handle);
 iotjs_handlewrap_t* iotjs_handlewrap_from_jobject(jerry_value_t jobject);
 
 uv_handle_t* iotjs_handlewrap_get_uv_handle(iotjs_handlewrap_t* handlewrap);
 jerry_value_t iotjs_handlewrap_jobject(iotjs_handlewrap_t* handlewrap);
 
 void iotjs_handlewrap_validate(iotjs_handlewrap_t* handlewrap);
-bool iotjs_handlewrap_validate_with_result(iotjs_handlewrap_t* handlewrap);
 
 #endif /* IOTJS_HANDLEWRAP_H */

--- a/src/iotjs_handlewrap.h
+++ b/src/iotjs_handlewrap.h
@@ -17,10 +17,10 @@
 #define IOTJS_HANDLEWRAP_H
 
 
-#include <uv.h>
-#include "iotjs_list.h"
 #include "iotjs_binding.h"
+#include "iotjs_list.h"
 #include "iotjs_objectwrap.h"
+#include <uv.h>
 
 
 typedef void (*OnCloseHandler)(uv_handle_t*);

--- a/src/iotjs_list.c
+++ b/src/iotjs_list.c
@@ -1,0 +1,245 @@
+//
+// list.c
+//
+// Copyright (c) 2010 TJ Holowaychuk <tj@vision-media.ca>
+//
+
+#include "iotjs_def.h"
+#include "iotjs_util.h"
+#include "iotjs_list.h"
+
+/*
+ * Allocate a new list_t. NULL on failure.
+ */
+list_t* list_new() {
+  list_t *self;
+  if (!(self = IOTJS_ALLOC(list_t)))
+    return NULL;
+  self->head = NULL;
+  self->tail = NULL;
+  self->free = NULL;
+  self->match = NULL;
+  self->len = 0;
+  return self;
+}
+
+/*
+ * Allocates a new list_node_t. NULL on failure.
+ */
+list_node_t* list_node_new(void *val) {
+  list_node_t *self;
+  if (!(self = IOTJS_ALLOC(list_node_t)))
+    return NULL;
+  self->prev = NULL;
+  self->next = NULL;
+  self->val = val;
+  return self;
+}
+
+/*
+ * Free the list.
+ */
+void list_destroy(list_t *self) {
+  unsigned int len = self->len;
+  list_node_t *next;
+  list_node_t *curr = self->head;
+
+  while (len--) {
+    next = curr->next;
+    if (self->free) self->free(curr->val);
+    IOTJS_RELEASE(curr);
+    curr = next;
+  }
+
+  IOTJS_RELEASE(self);
+}
+
+/*
+ * Append the given node to the list
+ * and return the node, NULL on failure.
+ */
+list_node_t* list_rpush(list_t *self, list_node_t *node) {
+  if (!node) return NULL;
+
+  if (self->len) {
+    node->prev = self->tail;
+    node->next = NULL;
+    self->tail->next = node;
+    self->tail = node;
+  } else {
+    self->head = self->tail = node;
+    node->prev = node->next = NULL;
+  }
+
+  ++self->len;
+  return node;
+}
+
+/*
+ * Return / detach the last node in the list, or NULL.
+ */
+list_node_t* list_rpop(list_t *self) {
+  if (!self->len) return NULL;
+
+  list_node_t *node = self->tail;
+
+  if (--self->len) {
+    (self->tail = node->prev)->next = NULL;
+  } else {
+    self->tail = self->head = NULL;
+  }
+
+  node->next = node->prev = NULL;
+  return node;
+}
+
+/*
+ * Return / detach the first node in the list, or NULL.
+ */
+list_node_t* list_lpop(list_t *self) {
+  if (!self->len) return NULL;
+
+  list_node_t *node = self->head;
+
+  if (--self->len) {
+    (self->head = node->next)->prev = NULL;
+  } else {
+    self->head = self->tail = NULL;
+  }
+
+  node->next = node->prev = NULL;
+  return node;
+}
+
+/*
+ * Prepend the given node to the list
+ * and return the node, NULL on failure.
+ */
+list_node_t* list_lpush(list_t *self, list_node_t *node) {
+  if (!node) return NULL;
+
+  if (self->len) {
+    node->next = self->head;
+    node->prev = NULL;
+    self->head->prev = node;
+    self->head = node;
+  } else {
+    self->head = self->tail = node;
+    node->prev = node->next = NULL;
+  }
+
+  ++self->len;
+  return node;
+}
+
+/*
+ * Return the node associated to val or NULL.
+ */
+list_node_t* list_find(list_t *self, void *val) {
+  list_iterator_t *it = list_iterator_new(self, LIST_HEAD);
+  list_node_t *node;
+
+  while ((node = list_iterator_next(it))) {
+    if (self->match) {
+      if (self->match(val, node->val)) {
+        list_iterator_destroy(it);
+        return node;
+      }
+    } else {
+      if (val == node->val) {
+        list_iterator_destroy(it);
+        return node;
+      }
+    }
+  }
+
+  list_iterator_destroy(it);
+  return NULL;
+}
+
+/*
+ * Return the node at the given index or NULL.
+ */
+list_node_t* list_at(list_t *self, int index) {
+  list_direction_t direction = LIST_HEAD;
+
+  if (index < 0) {
+    direction = LIST_TAIL;
+    index = ~index;
+  }
+
+  if ((unsigned)index < self->len) {
+    list_iterator_t *it = list_iterator_new(self, direction);
+    list_node_t *node = list_iterator_next(it);
+    while (index--) node = list_iterator_next(it);
+    list_iterator_destroy(it);
+    return node;
+  }
+
+  return NULL;
+}
+
+/*
+ * Remove the given node from the list, freeing it and it's value.
+ */
+void list_remove(list_t *self, list_node_t *node) {
+  node->prev
+    ? (node->prev->next = node->next)
+    : (self->head = node->next);
+
+  node->next
+    ? (node->next->prev = node->prev)
+    : (self->tail = node->prev);
+
+  if (self->free) self->free(node->val);
+
+  IOTJS_RELEASE(node);
+  --self->len;
+}
+
+/*
+ * Allocate a new list_iterator_t. NULL on failure.
+ * Accepts a direction, which may be LIST_HEAD or LIST_TAIL.
+ */
+list_iterator_t* list_iterator_new(list_t *list, list_direction_t direction) {
+  list_node_t *node = direction == LIST_HEAD
+    ? list->head
+    : list->tail;
+  return list_iterator_new_from_node(node, direction);
+}
+
+/*
+ * Allocate a new list_iterator_t with the given start
+ * node. NULL on failure.
+ */
+list_iterator_t* list_iterator_new_from_node(list_node_t *node, 
+                                             list_direction_t direction) {
+  list_iterator_t *self;
+  if (!(self = IOTJS_ALLOC(list_iterator_t)))
+    return NULL;
+  self->next = node;
+  self->direction = direction;
+  return self;
+}
+
+/*
+ * Return the next list_node_t or NULL when no more
+ * nodes remain in the list.
+ */
+list_node_t* list_iterator_next(list_iterator_t *self) {
+  list_node_t *curr = self->next;
+  if (curr) {
+    self->next = self->direction == LIST_HEAD
+      ? curr->next
+      : curr->prev;
+  }
+  return curr;
+}
+
+/*
+ * Free the list iterator.
+ */
+void list_iterator_destroy(list_iterator_t *self) {
+  IOTJS_RELEASE(self);
+  self = NULL;
+}

--- a/src/iotjs_list.c
+++ b/src/iotjs_list.c
@@ -5,13 +5,13 @@
 //
 
 #include "iotjs_def.h"
-#include "iotjs_util.h"
 #include "iotjs_list.h"
+#include "iotjs_util.h"
 
 /*
  * Allocate a new list_t. NULL on failure.
  */
-list_t* list_new() {
+list_t *list_new() {
   list_t *self;
   if (!(self = IOTJS_ALLOC(list_t)))
     return NULL;
@@ -26,7 +26,7 @@ list_t* list_new() {
 /*
  * Allocates a new list_node_t. NULL on failure.
  */
-list_node_t* list_node_new(void *val) {
+list_node_t *list_node_new(void *val) {
   list_node_t *self;
   if (!(self = IOTJS_ALLOC(list_node_t)))
     return NULL;
@@ -46,7 +46,8 @@ void list_destroy(list_t *self) {
 
   while (len--) {
     next = curr->next;
-    if (self->free) self->free(curr->val);
+    if (self->free)
+      self->free(curr->val);
     IOTJS_RELEASE(curr);
     curr = next;
   }
@@ -58,8 +59,9 @@ void list_destroy(list_t *self) {
  * Append the given node to the list
  * and return the node, NULL on failure.
  */
-list_node_t* list_rpush(list_t *self, list_node_t *node) {
-  if (!node) return NULL;
+list_node_t *list_rpush(list_t *self, list_node_t *node) {
+  if (!node)
+    return NULL;
 
   if (self->len) {
     node->prev = self->tail;
@@ -78,8 +80,9 @@ list_node_t* list_rpush(list_t *self, list_node_t *node) {
 /*
  * Return / detach the last node in the list, or NULL.
  */
-list_node_t* list_rpop(list_t *self) {
-  if (!self->len) return NULL;
+list_node_t *list_rpop(list_t *self) {
+  if (!self->len)
+    return NULL;
 
   list_node_t *node = self->tail;
 
@@ -96,8 +99,9 @@ list_node_t* list_rpop(list_t *self) {
 /*
  * Return / detach the first node in the list, or NULL.
  */
-list_node_t* list_lpop(list_t *self) {
-  if (!self->len) return NULL;
+list_node_t *list_lpop(list_t *self) {
+  if (!self->len)
+    return NULL;
 
   list_node_t *node = self->head;
 
@@ -115,8 +119,9 @@ list_node_t* list_lpop(list_t *self) {
  * Prepend the given node to the list
  * and return the node, NULL on failure.
  */
-list_node_t* list_lpush(list_t *self, list_node_t *node) {
-  if (!node) return NULL;
+list_node_t *list_lpush(list_t *self, list_node_t *node) {
+  if (!node)
+    return NULL;
 
   if (self->len) {
     node->next = self->head;
@@ -135,7 +140,7 @@ list_node_t* list_lpush(list_t *self, list_node_t *node) {
 /*
  * Return the node associated to val or NULL.
  */
-list_node_t* list_find(list_t *self, void *val) {
+list_node_t *list_find(list_t *self, void *val) {
   list_iterator_t *it = list_iterator_new(self, LIST_HEAD);
   list_node_t *node;
 
@@ -160,7 +165,7 @@ list_node_t* list_find(list_t *self, void *val) {
 /*
  * Return the node at the given index or NULL.
  */
-list_node_t* list_at(list_t *self, int index) {
+list_node_t *list_at(list_t *self, int index) {
   list_direction_t direction = LIST_HEAD;
 
   if (index < 0) {
@@ -171,7 +176,8 @@ list_node_t* list_at(list_t *self, int index) {
   if ((unsigned)index < self->len) {
     list_iterator_t *it = list_iterator_new(self, direction);
     list_node_t *node = list_iterator_next(it);
-    while (index--) node = list_iterator_next(it);
+    while (index--)
+      node = list_iterator_next(it);
     list_iterator_destroy(it);
     return node;
   }
@@ -183,15 +189,12 @@ list_node_t* list_at(list_t *self, int index) {
  * Remove the given node from the list, freeing it and it's value.
  */
 void list_remove(list_t *self, list_node_t *node) {
-  node->prev
-    ? (node->prev->next = node->next)
-    : (self->head = node->next);
+  node->prev ? (node->prev->next = node->next) : (self->head = node->next);
 
-  node->next
-    ? (node->next->prev = node->prev)
-    : (self->tail = node->prev);
+  node->next ? (node->next->prev = node->prev) : (self->tail = node->prev);
 
-  if (self->free) self->free(node->val);
+  if (self->free)
+    self->free(node->val);
 
   IOTJS_RELEASE(node);
   --self->len;
@@ -201,10 +204,8 @@ void list_remove(list_t *self, list_node_t *node) {
  * Allocate a new list_iterator_t. NULL on failure.
  * Accepts a direction, which may be LIST_HEAD or LIST_TAIL.
  */
-list_iterator_t* list_iterator_new(list_t *list, list_direction_t direction) {
-  list_node_t *node = direction == LIST_HEAD
-    ? list->head
-    : list->tail;
+list_iterator_t *list_iterator_new(list_t *list, list_direction_t direction) {
+  list_node_t *node = direction == LIST_HEAD ? list->head : list->tail;
   return list_iterator_new_from_node(node, direction);
 }
 
@@ -212,7 +213,7 @@ list_iterator_t* list_iterator_new(list_t *list, list_direction_t direction) {
  * Allocate a new list_iterator_t with the given start
  * node. NULL on failure.
  */
-list_iterator_t* list_iterator_new_from_node(list_node_t *node, 
+list_iterator_t *list_iterator_new_from_node(list_node_t *node,
                                              list_direction_t direction) {
   list_iterator_t *self;
   if (!(self = IOTJS_ALLOC(list_iterator_t)))
@@ -226,12 +227,10 @@ list_iterator_t* list_iterator_new_from_node(list_node_t *node,
  * Return the next list_node_t or NULL when no more
  * nodes remain in the list.
  */
-list_node_t* list_iterator_next(list_iterator_t *self) {
+list_node_t *list_iterator_next(list_iterator_t *self) {
   list_node_t *curr = self->next;
   if (curr) {
-    self->next = self->direction == LIST_HEAD
-      ? curr->next
-      : curr->prev;
+    self->next = self->direction == LIST_HEAD ? curr->next : curr->prev;
   }
   return curr;
 }

--- a/src/iotjs_list.h
+++ b/src/iotjs_list.h
@@ -1,0 +1,76 @@
+//
+// list.h
+//
+// Copyright (c) 2010 TJ Holowaychuk <tj@vision-media.ca>
+//
+
+#ifndef IOTJS_LIST_H
+#define IOTJS_LIST_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdlib.h>
+
+/*
+ * list_t iterator direction.
+ */
+typedef enum {
+  LIST_HEAD,
+  LIST_TAIL
+} list_direction_t;
+
+/*
+ * list_t node struct.
+ */
+typedef struct list_node {
+  struct list_node *prev;
+  struct list_node *next;
+  void *val;
+} list_node_t;
+
+/*
+ * list_t struct.
+ */
+typedef struct {
+  list_node_t *head;
+  list_node_t *tail;
+  unsigned int len;
+  void (*free)(void *val);
+  int (*match)(void *a, void *b);
+} list_t;
+
+/*
+ * list_t iterator struct.
+ */
+typedef struct {
+  list_node_t *next;
+  list_direction_t direction;
+} list_iterator_t;
+
+// Node prototypes.
+list_node_t* list_node_new(void *val);
+
+// list_t prototypes.
+list_t* list_new();
+list_node_t* list_rpush(list_t *self, list_node_t *node);
+list_node_t* list_lpush(list_t *self, list_node_t *node);
+list_node_t* list_find(list_t *self, void *val);
+list_node_t* list_at(list_t *self, int index);
+list_node_t* list_rpop(list_t *self);
+list_node_t* list_lpop(list_t *self);
+void list_remove(list_t *self, list_node_t *node);
+void list_destroy(list_t *self);
+
+// list_t iterator prototypes.
+list_iterator_t* list_iterator_new(list_t *list, list_direction_t direction);
+list_iterator_t* list_iterator_new_from_node(list_node_t *node, list_direction_t direction);
+list_node_t* list_iterator_next(list_iterator_t *self);
+void list_iterator_destroy(list_iterator_t *self);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* IOTJS_LIST_H */

--- a/src/iotjs_list.h
+++ b/src/iotjs_list.h
@@ -7,10 +7,6 @@
 #ifndef IOTJS_LIST_H
 #define IOTJS_LIST_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <stdlib.h>
 
 /*
@@ -68,9 +64,5 @@ list_iterator_t* list_iterator_new(list_t *list, list_direction_t direction);
 list_iterator_t* list_iterator_new_from_node(list_node_t *node, list_direction_t direction);
 list_node_t* list_iterator_next(list_iterator_t *self);
 void list_iterator_destroy(list_iterator_t *self);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* IOTJS_LIST_H */

--- a/src/iotjs_list.h
+++ b/src/iotjs_list.h
@@ -12,10 +12,7 @@
 /*
  * list_t iterator direction.
  */
-typedef enum {
-  LIST_HEAD,
-  LIST_TAIL
-} list_direction_t;
+typedef enum { LIST_HEAD, LIST_TAIL } list_direction_t;
 
 /*
  * list_t node struct.
@@ -46,23 +43,24 @@ typedef struct {
 } list_iterator_t;
 
 // Node prototypes.
-list_node_t* list_node_new(void *val);
+list_node_t *list_node_new(void *val);
 
 // list_t prototypes.
-list_t* list_new();
-list_node_t* list_rpush(list_t *self, list_node_t *node);
-list_node_t* list_lpush(list_t *self, list_node_t *node);
-list_node_t* list_find(list_t *self, void *val);
-list_node_t* list_at(list_t *self, int index);
-list_node_t* list_rpop(list_t *self);
-list_node_t* list_lpop(list_t *self);
+list_t *list_new();
+list_node_t *list_rpush(list_t *self, list_node_t *node);
+list_node_t *list_lpush(list_t *self, list_node_t *node);
+list_node_t *list_find(list_t *self, void *val);
+list_node_t *list_at(list_t *self, int index);
+list_node_t *list_rpop(list_t *self);
+list_node_t *list_lpop(list_t *self);
 void list_remove(list_t *self, list_node_t *node);
 void list_destroy(list_t *self);
 
 // list_t iterator prototypes.
-list_iterator_t* list_iterator_new(list_t *list, list_direction_t direction);
-list_iterator_t* list_iterator_new_from_node(list_node_t *node, list_direction_t direction);
-list_node_t* list_iterator_next(list_iterator_t *self);
+list_iterator_t *list_iterator_new(list_t *list, list_direction_t direction);
+list_iterator_t *list_iterator_new_from_node(list_node_t *node,
+                                             list_direction_t direction);
+list_node_t *list_iterator_next(list_iterator_t *self);
 void list_iterator_destroy(list_iterator_t *self);
 
 #endif /* IOTJS_LIST_H */

--- a/src/iotjs_string.h
+++ b/src/iotjs_string.h
@@ -16,7 +16,6 @@
 #ifndef IOTJS_STRING_H
 #define IOTJS_STRING_H
 
-
 typedef struct {
   size_t size;
   char* data;

--- a/src/iotjs_util.h
+++ b/src/iotjs_util.h
@@ -16,15 +16,7 @@
 #ifndef IOTJS_UTIL_H
 #define IOTJS_UTIL_H
 
-
 #include "iotjs_string.h"
-
-typedef struct list_node_s ListNode;
-typedef struct list_head_s ListHead;
-
-struct ListNode {
-  
-}
 
 char* iotjs__file_read(const char* path, size_t* outlen);
 // Return value should be released with iotjs_string_destroy()

--- a/src/iotjs_util.h
+++ b/src/iotjs_util.h
@@ -19,6 +19,12 @@
 
 #include "iotjs_string.h"
 
+typedef struct list_node_s ListNode;
+typedef struct list_head_s ListHead;
+
+struct ListNode {
+  
+}
 
 char* iotjs__file_read(const char* path, size_t* outlen);
 // Return value should be released with iotjs_string_destroy()


### PR DESCRIPTION
Fixed the build failure at #157 and a real fix to #143, it caused by the following error still:

```sh
/Users/travis/build/Rokid/ShadowNode/src/iotjs_handlewrap.c:136:20: error: comparison of address of 'handlewrap->unsafe' equal to a null pointer is always false [-Werror,-Wtautological-pointer-compare]
  if (&handlewrap->unsafe == NULL) {
       ~~~~~~~~~~~~^~~~~~    ~~~~
1 error generated.
```

### Why this patch?

This patch is related with how ShadowNode/IoT.js releases all the `HandleWrap` when program exits. The `HandleWrap` owns the `uv_handle_t` field. IoT.js releases them by `uv_walk` and its callback, which is called with an `uv_handle_t` object. 

The IoT.js asserts that every `uv_handle_t`'s `data` field is type of `HandleWrap`, That's working for these original modules, but now crashed for our new D-Bus module, that uses `uv_poll_t` and `uv_async_t` not as a `HandleWrap`.

I changed this to be checking if a `uv_handle_t` from a `HandleWrap` by its debug flag or `unsafe` field. After #157's failed build, We do think this implementation might be somehow not reliable! So the above is why this patch will be here.

### How to fix

In this patch, I'm doing:

- Remove the unneeded functions: `iotjs_handlewrap_validate_with_result()` and `iotjs_handlewrap_from_handle_unsafe()`.
- Introduce partially the library [clibs/list](https://github.com/clibs/list), a double linked list, as the `handlewrap` queue.
- In `handlewrap_initialize()`, push the instance into the above queue, and just remove it when destroy the handlewrap manually.
- Change the `uv_walk`'s callback only checks for `uv_handle_t`.
- Before `uv_walk`, clean up the queue of `HandleWrap`.

Therefore, we could clearly release these `HandleWrap`, and `uv_handle_t` as well. Request @algebrait @legendecas to have a review.
