### PR TITLE
jerry: fix test warnings

### DIFF
--- a/deps/jerry/tests/unit-core/test-snapshot.c
+++ b/deps/jerry/tests/unit-core/test-snapshot.c
@@ -223,7 +223,7 @@ main (void)
       0x20, 0x66, 0x72, 0x6F, 0x6D, 0x20, 0x73, 0x6E,
       0x61, 0x70, 0x73, 0x68, 0x6F, 0x74
     };
-    fprintf(stdout, "snapshot size: %d / %d\n", sizeof (expected_data), global_mode_snapshot_size);
+    fprintf(stdout, "snapshot size: %lu / %zu\n", sizeof (expected_data), global_mode_snapshot_size);
     TEST_ASSERT (sizeof (expected_data) == global_mode_snapshot_size);
     TEST_ASSERT (0 == memcmp (expected_data, global_mode_snapshot_buffer, sizeof (expected_data)));
 


### PR DESCRIPTION
Fix the following warnings:

```
/Users/travis/build/Rokid/ShadowNode/deps/jerry/tests/unit-core/test-snapshot.c:226:49: warning: format specifies type 'int' but the argument has type 'unsigned long' [-Wformat]
    fprintf(stdout, "snapshot size: %d / %d\n", sizeof (expected_data), global_mode_snapshot_size);
                                    ~~          ^~~~~~~~~~~~~~~~~~~~~~
                                    %lu
/Users/travis/build/Rokid/ShadowNode/deps/jerry/tests/unit-core/test-snapshot.c:226:73: warning: format specifies type 'int' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
    fprintf(stdout, "snapshot size: %d / %d\n", sizeof (expected_data), global_mode_snapshot_size);
                                         ~~                             ^~~~~~~~~~~~~~~~~~~~~~~~~
                                         %zu
2 warnings generated.
```