### PR TITLE
stream: writable#write shall respect chunk encoding

### DIFF
--- a/docs/api/Stream.md
+++ b/docs/api/Stream.md
@@ -367,8 +367,9 @@ var writable = new Writable({ highWaterMark:256 });
 ```
 
 
-### writable.end([chunk[, callback]])
+### writable.end([chunk][, encoding][, callback])
 * `chunk` {Buffer|string} Final data to write.
+* `encoding` {string} The encoding, if `chunk` is a string
 * `callback` {Function}
 
 Calling this function signals that no more data will
@@ -390,8 +391,9 @@ writable.end();
 ```
 
 
-### writable.write(chunk[, callback])
+### writable.write(chunk[, encoding][, callback])
 * `chunk` {Buffer|string} Data to write.
+* `encoding` {string} The encoding, if `chunk` is a string
 * `callback` {Function} Called when this chunk of data is flushed.
 * Returns: {boolean}
 
@@ -434,8 +436,9 @@ writable._readyToWrite();
 ```
 
 
-### writable._write(chunk, callback, onwrite)
+### writable._write(chunk, encoding, callback, onwrite)
 * `chunk` {Buffer|string} The data to be written by the stream.
+* `encoding` {string} If the chunk is a string, then `encoding` is the character encoding of that string. If chunk is a `Buffer`, or if the stream is operating in object mode, `encoding` may be ignored.
 * `callback` {Function} Callback to be called when the chunk of data is flushed.
 * `onwrite` {Function} Internal Callback to be called for when the chunk of data is flushed.
 
@@ -455,7 +458,7 @@ var Writable = require('stream').Writable;
 
 var writable = new Writable();
 
-writable._write = function(chunk, callback, onwrite) {
+writable._write = function(chunk, encoding, callback, onwrite) {
   // prints: message
   console.log(chunk);
 

--- a/src/js/buffer.js
+++ b/src/js/buffer.js
@@ -70,6 +70,8 @@ function Buffer(subject, encoding) {
           }
           break;
         default:
+          // defaults to utf8 encoding
+          // TODO: support ascii, latin1, utf16le encodings
           this.write(subject);
       }
     } else {

--- a/src/js/net.js
+++ b/src/js/net.js
@@ -165,7 +165,7 @@ Socket.prototype.write = function(data, callback) {
 };
 
 
-Socket.prototype._write = function(chunk, callback, afterWrite) {
+Socket.prototype._write = function(chunk, encoding, callback, afterWrite) {
   assert(util.isBuffer(chunk));
   assert(util.isFunction(afterWrite));
 

--- a/test/run_pass/test_stream_duplex.js
+++ b/test/run_pass/test_stream_duplex.js
@@ -25,7 +25,7 @@ assert(duplex.read);
 var msg1 = 'message 1';
 var msg2 = 'message 2';
 
-duplex._write = function(chunk, callback) {
+duplex._write = function(chunk, encoding, callback) {
   assert.equal(chunk == msg1, true);
   duplex.push(msg2);
   duplex.end();


### PR DESCRIPTION
writable#write shall pass chunk encoding to underlying stream implementation

- [x] document

## Effect on API Stability

3 api have changed in this PR. However the arguments order in 2 of them are not necessarily forced in order of `chunk, encoding, callback`, as second argument encoding is optional. 

A break change is introduced in this PR to `Writable#_write`. The function signature has changed from
```typescript
Writable#_write(chunk: Buffer | string, callback: Function, onwrite: Function)
```
to 
```typescript
Writable#_write(chunk: Buffer | string, encoding: string, callback: Function, onwrite: Function)
```