### PR TITLE
mqtt: remove unused members and spaces

### DIFF
--- a/src/modules/iotjs_module_mqtt.c
+++ b/src/modules/iotjs_module_mqtt.c
@@ -258,9 +258,9 @@ JS_FUNCTION(MqttGetAck) {
     return JS_CREATE_ERROR(COMMON, "invalid qos from message.");
   }
 
-  if (len <= 0)
+  if (len <= 0) {
     return JS_CREATE_ERROR(COMMON, "invalid serialization for ack.")
-
+  }
   jerry_value_t retbuf = iotjs_bufferwrap_create_buffer((size_t)len);
   iotjs_bufferwrap_t* wrap = iotjs_bufferwrap_from_jbuffer(retbuf);
   iotjs_bufferwrap_copy(wrap, (const char*)buf, (size_t)len);

--- a/src/modules/iotjs_module_mqtt.c
+++ b/src/modules/iotjs_module_mqtt.c
@@ -8,13 +8,10 @@ enum QoS { QOS0, QOS1, QOS2, SUBFAIL = 0x80 };
 
 typedef struct {
   iotjs_jobjectwrap_t jobjectwrap;
-  char* host;
-  int port;
   unsigned char* src;
   int srclen;
   int offset;
   MQTTPacket_connectData options_;
-  uv_loop_t* loop;
 } IOTJS_VALIDATED_STRUCT(iotjs_mqtt_t);
 
 static JNativeInfoType this_module_native_info = { .free_cb = NULL };
@@ -264,8 +261,7 @@ JS_FUNCTION(MqttGetAck) {
   if (len <= 0)
     return JS_CREATE_ERROR(COMMON, "invalid serialization for ack.")
 
-               jerry_value_t retbuf =
-                   iotjs_bufferwrap_create_buffer((size_t)len);
+  jerry_value_t retbuf = iotjs_bufferwrap_create_buffer((size_t)len);
   iotjs_bufferwrap_t* wrap = iotjs_bufferwrap_from_jbuffer(retbuf);
   iotjs_bufferwrap_copy(wrap, (const char*)buf, (size_t)len);
   return retbuf;


### PR DESCRIPTION
This found by this [codacy page](https://app.codacy.com/app/yorkie/ShadowNode/issues?bid=7916123&filters=W3siaWQiOiJMYW5ndWFnZSIsInZhbHVlcyI6WyJDIl19LHsiaWQiOiJDYXRlZ29yeSIsInZhbHVlcyI6W251bGxdfSx7ImlkIjoiTGV2ZWwiLCJ2YWx1ZXMiOltudWxsXX0seyJpZCI6IlBhdHRlcm4iLCJ2YWx1ZXMiOlsyMTE5XX0seyJpZCI6IkF1dGhvciIsInZhbHVlcyI6W251bGxdfSx7InZhbHVlcyI6W119XQ==) as the following:

- Struct member is never used.
- Statements following return, break, continue, goto or throw will never be executed.

Request reviews from @legendecas @algebrait :)