### PR TITLE
iotjs: improve the cli options, more like nodejs

### DIFF
--- a/src/iotjs.c
+++ b/src/iotjs.c
@@ -206,7 +206,6 @@ int iotjs_entry(int argc, char** argv) {
   // Parse command line arguments.
   if (!iotjs_environment_parse_command_line_arguments(env, (uint32_t)argc,
                                                       argv)) {
-    DLOG("iotjs_environment_parse_command_line_arguments failed");
     ret_code = 1;
     goto terminate;
   }

--- a/src/iotjs_debuglog.c
+++ b/src/iotjs_debuglog.c
@@ -19,19 +19,16 @@
 #include "iotjs_debuglog.h"
 
 #ifdef ENABLE_DEBUG_LOG
-#define COLOR_PRINT(id, str) "\033[" id "m" str "\033[0m"
 
 int iotjs_debug_level = DBGLEV_ERR;
 FILE* iotjs_log_stream;
-const char* iotjs_debug_prefix[4] = {
-  "",
-  COLOR_PRINT("31", "error"),
-  COLOR_PRINT("33", "warn"),
-  COLOR_PRINT("36", "info"),
+const iotjs_prefix_t iotjs_debug_prefix[4] = {
+  { .color = "", .text = "" },
+  { .color = "31", .text = "error" },
+  { .color = "33", .text = "warn" },
+  { .color = "36", .text = "info" },
 };
-#undef COLOR_PRINT
 #endif // ENABLE_DEBUG_LOG
-
 
 void init_debug_settings() {
 #ifdef ENABLE_DEBUG_LOG

--- a/src/iotjs_debuglog.c
+++ b/src/iotjs_debuglog.c
@@ -19,9 +19,17 @@
 #include "iotjs_debuglog.h"
 
 #ifdef ENABLE_DEBUG_LOG
+#define COLOR_PRINT(id, str) "\033[" id "m" str "\033[0m"
+
 int iotjs_debug_level = DBGLEV_ERR;
 FILE* iotjs_log_stream;
-const char* iotjs_debug_prefix[4] = { "", "ERR", "WRN", "INF" };
+const char* iotjs_debug_prefix[4] = { 
+  "",
+  COLOR_PRINT("31", "error"),
+  COLOR_PRINT("33", "warn"),
+  COLOR_PRINT("36", "info"),
+};
+#undef COLOR_PRINT
 #endif // ENABLE_DEBUG_LOG
 
 

--- a/src/iotjs_debuglog.c
+++ b/src/iotjs_debuglog.c
@@ -23,7 +23,7 @@
 
 int iotjs_debug_level = DBGLEV_ERR;
 FILE* iotjs_log_stream;
-const char* iotjs_debug_prefix[4] = { 
+const char* iotjs_debug_prefix[4] = {
   "",
   COLOR_PRINT("31", "error"),
   COLOR_PRINT("33", "warn"),

--- a/src/iotjs_debuglog.h
+++ b/src/iotjs_debuglog.h
@@ -38,14 +38,15 @@ extern const iotjs_prefix_t iotjs_debug_prefix[4];
 /*
  * test with "nohup iotjs > /my.log 2>&1 < /dev/null"
  */
-#define DBG_COLOR_PRINT(prefix) do {                                \
-  if (isatty(0) == 1) {                                             \
-    fprintf(iotjs_log_stream,                                       \
-      "\033[%sm%s\033[0m ", prefix.color, prefix.text);             \
-  } else {                                                          \
-    fprintf(iotjs_log_stream, "[%s] ", prefix.text);                \
-  }                                                                 \
-} while (0)
+#define DBG_COLOR_PRINT(prefix)                                     \
+  do {                                                              \
+    if (isatty(0) == 1) {                                           \
+      fprintf(iotjs_log_stream, "\033[%sm%s\033[0m ", prefix.color, \
+              prefix.text);                                         \
+    } else {                                                        \
+      fprintf(iotjs_log_stream, "[%s] ", prefix.text);              \
+    }                                                               \
+  } while (0)
 
 #define IOTJS_DLOG(lvl, ...)                                        \
   do {                                                              \

--- a/src/iotjs_debuglog.h
+++ b/src/iotjs_debuglog.h
@@ -32,7 +32,7 @@ extern const char* iotjs_debug_prefix[4];
 #define IOTJS_DLOG(lvl, ...)                                        \
   do {                                                              \
     if (0 <= lvl && lvl <= iotjs_debug_level && iotjs_log_stream) { \
-      fprintf(iotjs_log_stream, "%s ", iotjs_debug_prefix[lvl]);  \
+      fprintf(iotjs_log_stream, "%s ", iotjs_debug_prefix[lvl]);    \
       fprintf(iotjs_log_stream, __VA_ARGS__);                       \
       fprintf(iotjs_log_stream, "\n");                              \
       fflush(iotjs_log_stream);                                     \

--- a/src/iotjs_debuglog.h
+++ b/src/iotjs_debuglog.h
@@ -32,7 +32,7 @@ extern const char* iotjs_debug_prefix[4];
 #define IOTJS_DLOG(lvl, ...)                                        \
   do {                                                              \
     if (0 <= lvl && lvl <= iotjs_debug_level && iotjs_log_stream) { \
-      fprintf(iotjs_log_stream, "[%s] ", iotjs_debug_prefix[lvl]);  \
+      fprintf(iotjs_log_stream, "%s ", iotjs_debug_prefix[lvl]);  \
       fprintf(iotjs_log_stream, __VA_ARGS__);                       \
       fprintf(iotjs_log_stream, "\n");                              \
       fflush(iotjs_log_stream);                                     \

--- a/src/iotjs_debuglog.h
+++ b/src/iotjs_debuglog.h
@@ -20,19 +20,37 @@
 #ifdef ENABLE_DEBUG_LOG
 
 #include <stdio.h>
+#include <unistd.h>
+
+typedef struct iotjs_prefix_s {
+  const char* color;
+  const char* text;
+} iotjs_prefix_t;
 
 extern int iotjs_debug_level;
 extern FILE* iotjs_log_stream;
-extern const char* iotjs_debug_prefix[4];
+extern const iotjs_prefix_t iotjs_debug_prefix[4];
 
 #define DBGLEV_ERR 1
 #define DBGLEV_WARN 2
 #define DBGLEV_INFO 3
 
+/*
+ * test with "nohup iotjs > /my.log 2>&1 < /dev/null"
+ */
+#define DBG_COLOR_PRINT(prefix) do {                                \
+  if (isatty(0) == 1) {                                             \
+    fprintf(iotjs_log_stream,                                       \
+      "\033[%sm%s\033[0m ", prefix.color, prefix.text);             \
+  } else {                                                          \
+    fprintf(iotjs_log_stream, "[%s] ", prefix.text);                \
+  }                                                                 \
+} while (0)
+
 #define IOTJS_DLOG(lvl, ...)                                        \
   do {                                                              \
     if (0 <= lvl && lvl <= iotjs_debug_level && iotjs_log_stream) { \
-      fprintf(iotjs_log_stream, "%s ", iotjs_debug_prefix[lvl]);    \
+      DBG_COLOR_PRINT(iotjs_debug_prefix[lvl]);                     \
       fprintf(iotjs_log_stream, __VA_ARGS__);                       \
       fprintf(iotjs_log_stream, "\n");                              \
       fflush(iotjs_log_stream);                                     \

--- a/src/iotjs_env.c
+++ b/src/iotjs_env.c
@@ -99,6 +99,28 @@ static void iotjs_environment_destroy(iotjs_environment_t* env) {
   }
 }
 
+void iotjs_environment_print_help() {
+  fprintf(stderr, "Usage: iotjs [options] [script | script.js] [arguments]\n"
+                  "\n"
+                  "Options:\n"
+                  "  -v, --version              print version\n"
+                  "  -h, --help                 print help\n"
+                  "  --loadstat                 print the load statistics\n"
+                  "  --memstat                  print the memory statistics\n"
+                  "  --show-opcodes             print the opcodes of running script\n"
+                  "  --start-debug-server       activate the debugger server\n\n"
+                  "Environment variables:\n"
+                  "NODE_DISABLE_COLORS          set to 1 to disable colors in the REPL\n"
+                  "NODE_PATH                    ':'-separated list of directories\n"
+                  "                             prefixed to the module search path\n"
+                  "\nDocumentation can be found at "
+                  "https://github.com/Rokid/ShadowNode/tree/master/docs\n");
+}
+
+void iotjs_environment_print_version() {
+  fprintf(stdout, "v" NODE_MAJOR_VERSION "." NODE_MINOR_VERSION
+                  "." NODE_PATCH_VERSION "\n");
+}
 
 /**
  * Parse command line arguments
@@ -112,7 +134,13 @@ bool iotjs_environment_parse_command_line_arguments(iotjs_environment_t* env,
   uint32_t i = 1;
   uint8_t port_arg_len = strlen("--jerry-debugger-port=");
   while (i < argc && argv[i][0] == '-') {
-    if (!strcmp(argv[i], "--loadstat")) {
+    if (!strcmp(argv[i], "-h") || !strcmp(argv[i], "--help")) {
+      iotjs_environment_print_help();
+      return false;
+    } else if (!strcmp(argv[i], "-v") || !strcmp(argv[i], "--version")) {
+      iotjs_environment_print_version();
+      return false;
+    } else if (!strcmp(argv[i], "--loadstat")) {
       _this->config.loadstat = true;
     } else if (!strcmp(argv[i], "--memstat")) {
       _this->config.memstat = true;
@@ -144,10 +172,7 @@ bool iotjs_environment_parse_command_line_arguments(iotjs_environment_t* env,
   // except when sources are sent over by the debugger client.
   if ((argc - i) < 1 && (_this->config.debugger == NULL ||
                          !_this->config.debugger->wait_source)) {
-    fprintf(stderr, "Version: v" NODE_MAJOR_VERSION "." NODE_MINOR_VERSION
-                    "." NODE_PATCH_VERSION "\n");
-    fprintf(stderr,
-            "Usage: iotjs [options] {script | script.js} [arguments]\n\n");
+    iotjs_environment_print_help();
     return false;
   }
 

--- a/src/iotjs_env.c
+++ b/src/iotjs_env.c
@@ -100,21 +100,22 @@ static void iotjs_environment_destroy(iotjs_environment_t* env) {
 }
 
 void iotjs_environment_print_help() {
-  fprintf(stderr, "Usage: iotjs [options] [script | script.js] [arguments]\n"
-                  "\n"
-                  "Options:\n"
-                  "  -v, --version              print version\n"
-                  "  -h, --help                 print help\n"
-                  "  --loadstat                 print the load statistics\n"
-                  "  --memstat                  print the memory statistics\n"
-                  "  --show-opcodes             print the opcodes of running script\n"
-                  "  --start-debug-server       activate the debugger server\n\n"
-                  "Environment variables:\n"
-                  "NODE_DISABLE_COLORS          set to 1 to disable colors in the REPL\n"
-                  "NODE_PATH                    ':'-separated list of directories\n"
-                  "                             prefixed to the module search path\n"
-                  "\nDocumentation can be found at "
-                  "https://github.com/Rokid/ShadowNode/tree/master/docs\n");
+  fprintf(
+    stderr,
+    "Usage: iotjs [options] [script | script.js] [arguments]\n\n"
+    "Options:\n"
+    "  -v, --version              print version\n"
+    "  -h, --help                 print help\n"
+    "  --loadstat                 print the load statistics\n"
+    "  --memstat                  print the memory statistics\n"
+    "  --show-opcodes             print the opcodes of running script\n"
+    "  --start-debug-server       activate the debugger server\n\n"
+    "Environment variables:\n"
+    "NODE_DISABLE_COLORS          set to 1 to disable colors in the REPL\n"
+    "NODE_PATH                    ':'-separated list of directories\n"
+    "                             prefixed to the module search path\n"
+    "\nDocumentation can be found at "
+    "https://github.com/Rokid/ShadowNode/tree/master/docs\n");
 }
 
 void iotjs_environment_print_version() {

--- a/src/iotjs_env.c
+++ b/src/iotjs_env.c
@@ -101,21 +101,21 @@ static void iotjs_environment_destroy(iotjs_environment_t* env) {
 
 void iotjs_environment_print_help() {
   fprintf(
-    stderr,
-    "Usage: iotjs [options] [script | script.js] [arguments]\n\n"
-    "Options:\n"
-    "  -v, --version              print version\n"
-    "  -h, --help                 print help\n"
-    "  --loadstat                 print the load statistics\n"
-    "  --memstat                  print the memory statistics\n"
-    "  --show-opcodes             print the opcodes of running script\n"
-    "  --start-debug-server       activate the debugger server\n\n"
-    "Environment variables:\n"
-    "NODE_DISABLE_COLORS          set to 1 to disable colors in the REPL\n"
-    "NODE_PATH                    ':'-separated list of directories\n"
-    "                             prefixed to the module search path\n"
-    "\nDocumentation can be found at "
-    "https://github.com/Rokid/ShadowNode/tree/master/docs\n");
+      stderr,
+      "Usage: iotjs [options] [script | script.js] [arguments]\n\n"
+      "Options:\n"
+      "  -v, --version              print version\n"
+      "  -h, --help                 print help\n"
+      "  --loadstat                 print the load statistics\n"
+      "  --memstat                  print the memory statistics\n"
+      "  --show-opcodes             print the opcodes of running script\n"
+      "  --start-debug-server       activate the debugger server\n\n"
+      "Environment variables:\n"
+      "NODE_DISABLE_COLORS          set to 1 to disable colors in the REPL\n"
+      "NODE_PATH                    ':'-separated list of directories\n"
+      "                             prefixed to the module search path\n"
+      "\nDocumentation can be found at "
+      "https://github.com/Rokid/ShadowNode/tree/master/docs\n");
 }
 
 void iotjs_environment_print_version() {

--- a/test.js
+++ b/test.js
@@ -1,0 +1,2 @@
+var crypto = require('crypto');
+console.log(crypto);

--- a/test.js
+++ b/test.js
@@ -1,2 +1,0 @@
-var crypto = require('crypto');
-console.log(crypto);


### PR DESCRIPTION
Now we are closer to Node.js style command line tool:

```sh
> iotjs -v
v0.8.5
> iotjs --version
v0.8.5
> iotjs --help
Usage: iotjs [options] [script | script.js] [arguments]

Options:
  -v, --version              print version
  -h, --help                 print help
  --loadstat                 print the load statistics
  --memstat                  print the memory statistics
  --show-opcodes             print the opcodes of running script
  --start-debug-server       activate the debugger server

Environment variables:
NODE_DISABLE_COLORS          set to 1 to disable colors in the REPL
NODE_PATH                    ':'-separated list of directories
                             prefixed to the module search path

Documentation can be found at https://github.com/Rokid/ShadowNode/tree/master/docs
```