### PR TITLE
child_process: free blocks from strdup() which causes memory leaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,4 +40,16 @@ matrix:
       os: osx
       install: tools/brew-install-deps.sh
 
+before_deploy:
+  - git config --local user.name "yorkie"
+  - git config --local user.email "yorkiefixer@gmail.com"
+  - git tag "$(date +'%Y%m%d%H%M%S')-$(git log --format=%h -1)"
+
+deploy:
+  privider: releases
+  skip_cleanup: true
+  api_key: $GITHUB_TOKEN
+  on:
+    tags: true
+
 fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,16 +40,4 @@ matrix:
       os: osx
       install: tools/brew-install-deps.sh
 
-before_deploy:
-  - git config --local user.name "yorkie"
-  - git config --local user.email "yorkiefixer@gmail.com"
-  - git tag "$(date +'%Y%m%d%H%M%S')-$(git log --format=%h -1)"
-
-deploy:
-  privider: releases
-  skip_cleanup: true
-  api_key: $GITHUB_TOKEN
-  on:
-    tags: true
-
 fast_finish: true

--- a/src/modules/iotjs_module_child_process.c
+++ b/src/modules/iotjs_module_child_process.c
@@ -89,8 +89,8 @@ JS_FUNCTION(ProcessConstructor) {
   return jerry_create_undefined();
 }
 
-static uint32_t iotjs_processwrap_parse_args_opts(jerry_value_t js_options,
-                                              uv_process_options_t* options) {
+static uint32_t iotjs_processwrap_parse_args_opts(
+    jerry_value_t js_options, uv_process_options_t* options) {
   jerry_value_t jarr = iotjs_jval_get_property(js_options, "args");
   uint32_t len = jerry_get_array_length(jarr);
   if (len > 0) {
@@ -110,8 +110,8 @@ static uint32_t iotjs_processwrap_parse_args_opts(jerry_value_t js_options,
   return len;
 }
 
-static uint32_t iotjs_processwrap_parse_envs_opts(jerry_value_t js_options,
-                                              uv_process_options_t* options) {
+static uint32_t iotjs_processwrap_parse_envs_opts(
+    jerry_value_t js_options, uv_process_options_t* options) {
   jerry_value_t jarr = iotjs_jval_get_property(js_options, "envPairs");
   uint32_t len = jerry_get_array_length(jarr);
   if (len > 0) {
@@ -198,7 +198,7 @@ JS_FUNCTION(ProcessSpawn) {
     if (!jerry_value_is_undefined(val) && !jerry_value_is_null(val)) { \
       iotjs_string_t str = iotjs_jval_as_string(val);                  \
       options.name = strdup(iotjs_string_data(&str));                  \
-      iotjs_string_destroy(&str); \
+      iotjs_string_destroy(&str);                                      \
     }                                                                  \
     jerry_release_value(val);                                          \
   } while (0)
@@ -210,8 +210,8 @@ JS_FUNCTION(ProcessSpawn) {
 #undef IOTJS_PROCESS_SET_XID
 #undef IOTJS_PROCESS_SET_STRING
 
-  uint32_t args_len = iotjs_processwrap_parse_args_opts(js_options, &options);
-  uint32_t envs_len = iotjs_processwrap_parse_envs_opts(js_options, &options);
+  iotjs_processwrap_parse_args_opts(js_options, &options);
+  iotjs_processwrap_parse_envs_opts(js_options, &options);
   iotjs_processwrap_parse_stdio_opts(js_options, &options);
   jerry_release_value(js_options);
 
@@ -225,13 +225,15 @@ JS_FUNCTION(ProcessSpawn) {
 
   if (options.args != NULL) {
     for (uint32_t i = 0; i < args_len; i++)
-      if (options.args[i] != NULL) free(options.args[i]);
+      if (options.args[i] != NULL)
+        free(options.args[i]);
     free(options.args);
   }
 
   if (options.env != NULL) {
     for (uint32_t i = 0; i < envs_len; i++)
-      if (options.env[i] != NULL) free(options.env[i]);
+      if (options.env[i] != NULL)
+        free(options.env[i]);
     free(options.env);
   }
 

--- a/src/modules/iotjs_module_child_process.c
+++ b/src/modules/iotjs_module_child_process.c
@@ -89,7 +89,7 @@ JS_FUNCTION(ProcessConstructor) {
   return jerry_create_undefined();
 }
 
-static void iotjs_processwrap_parse_args_opts(jerry_value_t js_options,
+static uint32_t iotjs_processwrap_parse_args_opts(jerry_value_t js_options,
                                               uv_process_options_t* options) {
   jerry_value_t jarr = iotjs_jval_get_property(js_options, "args");
   uint32_t len = jerry_get_array_length(jarr);
@@ -98,6 +98,8 @@ static void iotjs_processwrap_parse_args_opts(jerry_value_t js_options,
     for (uint32_t i = 0; i < len; i++) {
       jerry_value_t jval = iotjs_jval_get_property_by_index(jarr, i);
       iotjs_string_t str = iotjs_jval_as_string(jval);
+
+      // TODO(Yorkie): check if this allocated block are valid.
       options->args[i] = (char*)strdup(iotjs_string_data(&str));
       iotjs_string_destroy(&str);
       jerry_release_value(jval);
@@ -105,9 +107,10 @@ static void iotjs_processwrap_parse_args_opts(jerry_value_t js_options,
     options->args[len] = NULL;
   }
   jerry_release_value(jarr);
+  return len;
 }
 
-static void iotjs_processwrap_parse_envs_opts(jerry_value_t js_options,
+static uint32_t iotjs_processwrap_parse_envs_opts(jerry_value_t js_options,
                                               uv_process_options_t* options) {
   jerry_value_t jarr = iotjs_jval_get_property(js_options, "envPairs");
   uint32_t len = jerry_get_array_length(jarr);
@@ -116,6 +119,8 @@ static void iotjs_processwrap_parse_envs_opts(jerry_value_t js_options,
     for (uint32_t i = 0; i < len; i++) {
       jerry_value_t jval = iotjs_jval_get_property_by_index(jarr, i);
       iotjs_string_t str = iotjs_jval_as_string(jval);
+
+      // TODO(Yorkie): check if this allocated block are valid.
       options->env[i] = (char*)strdup(iotjs_string_data(&str));
       iotjs_string_destroy(&str);
       jerry_release_value(jval);
@@ -123,6 +128,7 @@ static void iotjs_processwrap_parse_envs_opts(jerry_value_t js_options,
     options->env[len] = NULL;
   }
   jerry_release_value(jarr);
+  return len;
 }
 
 static void iotjs_processwrap_parse_stdio_opts(jerry_value_t js_options,
@@ -191,7 +197,8 @@ JS_FUNCTION(ProcessSpawn) {
     jerry_value_t val = iotjs_jval_get_property(js_options, #name);    \
     if (!jerry_value_is_undefined(val) && !jerry_value_is_null(val)) { \
       iotjs_string_t str = iotjs_jval_as_string(val);                  \
-      options.name = iotjs_string_data(&str);                          \
+      options.name = strdup(iotjs_string_data(&str));                  \
+      iotjs_string_destroy(&str); \
     }                                                                  \
     jerry_release_value(val);                                          \
   } while (0)
@@ -203,8 +210,8 @@ JS_FUNCTION(ProcessSpawn) {
 #undef IOTJS_PROCESS_SET_XID
 #undef IOTJS_PROCESS_SET_STRING
 
-  iotjs_processwrap_parse_args_opts(js_options, &options);
-  iotjs_processwrap_parse_envs_opts(js_options, &options);
+  uint32_t args_len = iotjs_processwrap_parse_args_opts(js_options, &options);
+  uint32_t envs_len = iotjs_processwrap_parse_envs_opts(js_options, &options);
   iotjs_processwrap_parse_stdio_opts(js_options, &options);
   jerry_release_value(js_options);
 
@@ -217,14 +224,30 @@ JS_FUNCTION(ProcessSpawn) {
   }
 
   if (options.args != NULL) {
+    for (uint32_t i = 0; i < args_len; i++)
+      if (options.args[i] != NULL) free(options.args[i]);
     free(options.args);
   }
 
   if (options.env != NULL) {
+    for (uint32_t i = 0; i < envs_len; i++)
+      if (options.env[i] != NULL) free(options.env[i]);
     free(options.env);
   }
 
-  return jerry_create_number(err);
+  if (options.file != NULL) {
+    free((void*)options.file);
+  }
+
+  if (options.cwd != NULL) {
+    free((void*)options.cwd);
+  }
+
+  if (options.stdio != NULL) {
+    free((void*)options.stdio);
+  }
+
+  return jerry_create_number(0);
 }
 
 JS_FUNCTION(ProcessKill) {

--- a/src/modules/iotjs_module_child_process.c
+++ b/src/modules/iotjs_module_child_process.c
@@ -210,8 +210,8 @@ JS_FUNCTION(ProcessSpawn) {
 #undef IOTJS_PROCESS_SET_XID
 #undef IOTJS_PROCESS_SET_STRING
 
-  iotjs_processwrap_parse_args_opts(js_options, &options);
-  iotjs_processwrap_parse_envs_opts(js_options, &options);
+  uint32_t args_len = iotjs_processwrap_parse_args_opts(js_options, &options);
+  uint32_t envs_len = iotjs_processwrap_parse_envs_opts(js_options, &options);
   iotjs_processwrap_parse_stdio_opts(js_options, &options);
   jerry_release_value(js_options);
 

--- a/test/memory/child_process.js
+++ b/test/memory/child_process.js
@@ -7,9 +7,11 @@ var matrix = {
   startRss: 0,
   endRss: 0,
   samples: 0,
+  increasingCount: 0,
+  decreasingCount: 0,
 };
 
-var duration = process.argv[2] || 5000;
+var duration = process.argv[2] || 7000;
 var cycle = process.argv[3] || 0;
 
 (function main() {
@@ -22,9 +24,14 @@ var cycle = process.argv[3] || 0;
         matrix.startRss = curr;
       matrix.endRss = rss;
       matrix.samples += 1;
+      if (curr - rss > 0) {
+        matrix.increasingCount += 1;
+      } else if (curr - rss < 0) {
+        matrix.decreasingCount += 1;
+      }
     }
-    if (curr - rss > 0) {
-      console.log(`> total: ${curr}, increase: ${curr - rss}`);
+    if (curr - rss !== 0) {
+      console.log(`:: ${curr} + ${curr - rss} bytes`);
     }
     main();
   }, cycle);
@@ -32,11 +39,17 @@ var cycle = process.argv[3] || 0;
 
 function summary() {
   clearTimeout(profilingHandle);
-  console.log(`Memory Leak Summary(${matrix.samples} samples):`);
+  console.log(`\nMemory Summary(${matrix.samples} samples):`);
+  console.log(` Duration ${duration/1000}s`);
   console.log(` Rss(From): ${matrix.startRss}`);
   console.log(` Rss(End ): ${matrix.endRss}`);
   console.log(` Detects ${matrix.endRss - matrix.startRss} bytes`);
-  process.exit();
+  console.log('====================================================');
+  console.log(` Increasing Count  : ${matrix.increasingCount} / ${matrix.samples}`);
+  console.log(` Decreasing Count  : ${matrix.decreasingCount} / ${matrix.samples}`);
+  console.log(` Increasing Rate   : ${parseInt((matrix.increasingCount / matrix.samples) * 100)}%`);
+  console.log(` Decreasing Rate   : ${parseInt((matrix.decreasingCount / matrix.samples) * 100)}%`);
+  setTimeout(process.exit, 500);
 }
 
 setTimeout(() => {

--- a/test/memory/child_process.js
+++ b/test/memory/child_process.js
@@ -1,13 +1,38 @@
 'use strict';
 
 var exec = require('child_process').exec;
+var startProfiling = false;
+var matrix = {
+  startRss: 0,
+  endRss: 0,
+  samples: 0,
+};
 
 (function main() {
   var rss = process.memoryUsage().rss;
   exec('ls', (err) => err && console.error(err));
   setTimeout(() => {
     var curr = process.memoryUsage().rss;
+    if (startProfiling) {
+      if (!matrix.startRss)
+        matrix.startRss = curr;
+      matrix.endRss = rss;
+      matrix.samples += 1;
+    }
     console.log(`> total: ${curr}, increase: ${curr - rss}`);
     main();
-  }, 100)
+  }, 0);
 })();
+
+function summary() {
+  console.log(`Memory Leak Summary(${matrix.samples} samples):`);
+  console.log(` Rss(From): ${matrix.startRss}`);
+  console.log(` Rss(End ): ${matrix.endRss}`);
+  console.log(` Detects ${matrix.endRss - matrix.startRss} bytes`);
+  process.exit();
+}
+
+setTimeout(() => {
+  startProfiling = true;
+  setTimeout(summary, 5 * 1000);
+}, 2 * 1000);

--- a/test/memory/child_process.js
+++ b/test/memory/child_process.js
@@ -1,0 +1,13 @@
+'use strict';
+
+var exec = require('child_process').exec;
+
+(function main() {
+  var rss = process.memoryUsage().rss;
+  exec('ls', (err) => err && console.error(err));
+  setTimeout(() => {
+    var curr = process.memoryUsage().rss;
+    console.log(`> total: ${curr}, increase: ${curr - rss}`);
+    main();
+  }, 100)
+})();

--- a/test/memory/child_process.js
+++ b/test/memory/child_process.js
@@ -8,6 +8,9 @@ var matrix = {
   samples: 0,
 };
 
+var duration = process.argv[2] || 5000;
+var cycle = process.argv[3] || 0;
+
 (function main() {
   var rss = process.memoryUsage().rss;
   exec('ls', (err) => err && console.error('error', err));
@@ -21,7 +24,7 @@ var matrix = {
     }
     console.log(`> total: ${curr}, increase: ${curr - rss}`);
     main();
-  }, 0);
+  }, cycle);
 })();
 
 function summary() {
@@ -34,5 +37,5 @@ function summary() {
 
 setTimeout(() => {
   startProfiling = true;
-  setTimeout(summary, 5 * 1000);
+  setTimeout(summary, duration);
 }, 500);

--- a/test/memory/child_process.js
+++ b/test/memory/child_process.js
@@ -10,7 +10,7 @@ var matrix = {
 
 (function main() {
   var rss = process.memoryUsage().rss;
-  exec('ls', (err) => err && console.error(err));
+  exec('ls', (err) => err && console.error('error', err));
   setTimeout(() => {
     var curr = process.memoryUsage().rss;
     if (startProfiling) {
@@ -35,4 +35,4 @@ function summary() {
 setTimeout(() => {
   startProfiling = true;
   setTimeout(summary, 5 * 1000);
-}, 100);
+}, 500);

--- a/test/memory/child_process.js
+++ b/test/memory/child_process.js
@@ -2,6 +2,7 @@
 
 var exec = require('child_process').exec;
 var startProfiling = false;
+var profilingHandle = null;
 var matrix = {
   startRss: 0,
   endRss: 0,
@@ -14,7 +15,7 @@ var cycle = process.argv[3] || 0;
 (function main() {
   var rss = process.memoryUsage().rss;
   exec('ls', (err) => err && console.error('error', err));
-  setTimeout(() => {
+  profilingHandle = setTimeout(() => {
     var curr = process.memoryUsage().rss;
     if (startProfiling) {
       if (!matrix.startRss)
@@ -22,12 +23,15 @@ var cycle = process.argv[3] || 0;
       matrix.endRss = rss;
       matrix.samples += 1;
     }
-    console.log(`> total: ${curr}, increase: ${curr - rss}`);
+    if (curr - rss > 0) {
+      console.log(`> total: ${curr}, increase: ${curr - rss}`);
+    }
     main();
   }, cycle);
 })();
 
 function summary() {
+  clearTimeout(profilingHandle);
   console.log(`Memory Leak Summary(${matrix.samples} samples):`);
   console.log(` Rss(From): ${matrix.startRss}`);
   console.log(` Rss(End ): ${matrix.endRss}`);

--- a/test/memory/child_process.js
+++ b/test/memory/child_process.js
@@ -35,4 +35,4 @@ function summary() {
 setTimeout(() => {
   startProfiling = true;
   setTimeout(summary, 5 * 1000);
-}, 2 * 1000);
+}, 100);


### PR DESCRIPTION
This is going to fix almost #195, the memory leaks from `child_process`. This shows the data list of the leaks:

| codebase | rss(from) | rss(to) | leaked bytes |
|-----------|----------|--------|--------------|
|  [master](https://github.com/Rokid/ShadowNode/tree/master)     | 2654208 | 3555328 | 901120 |
| [fix/gh-195](https://github.com/Rokid/ShadowNode/tree/fix/gh-195) | 2576384 | 3002368 | 425984 |

Added a memory test script as well, someone could run by:

```sh
$ iotjs test/memory/child_process.js
Memory Leak Summary(389 samples):
 Rss(From): 2654208
 Rss(End ): 3555328
 Detects 901120 bytes
```

@legendecas @lolBig Needs your reviews on this PR.
