### PR TITLE
pipe: release iotjs_string when write complete

### DIFF
--- a/src/modules/iotjs_module_pipe.c
+++ b/src/modules/iotjs_module_pipe.c
@@ -174,7 +174,7 @@ JS_FUNCTION(WriteUtf8String) {
   const size_t size = iotjs_string_size(&data);
   buf = uv_buf_init((char*)chunk, size);
   int r = uv_try_write((uv_stream_t*)&_this->handle, &buf, 1);
-  
+
   // free the data firstly
   iotjs_string_destroy(&data);
   if (r < 0) {

--- a/src/modules/iotjs_module_pipe.c
+++ b/src/modules/iotjs_module_pipe.c
@@ -169,8 +169,14 @@ JS_FUNCTION(WriteUtf8String) {
 
   iotjs_string_t data = JS_GET_ARG(0, string);
   uv_buf_t buf;
-  buf = uv_buf_init((char*)iotjs_string_data(&data), iotjs_string_size(&data));
+
+  const char* chunk = iotjs_string_data(&data);
+  const size_t size = iotjs_string_size(&data);
+  buf = uv_buf_init((char*)chunk, size);
   int r = uv_try_write((uv_stream_t*)&_this->handle, &buf, 1);
+  
+  // free the data firstly
+  iotjs_string_destroy(&data);
   if (r < 0) {
     return JS_CREATE_ERROR(COMMON, "failed to write to stream.");
   }

--- a/test/memory/issue/issue-199/child.js
+++ b/test/memory/issue/issue-199/child.js
@@ -1,0 +1,5 @@
+'use strict';
+
+setInterval(() => {
+  process.send(Math.random())
+}, 0);

--- a/test/memory/issue/issue-199/parent.js
+++ b/test/memory/issue/issue-199/parent.js
@@ -1,0 +1,11 @@
+'use strict';
+
+var child = require('child_process').fork(__dirname + '/child.js', {
+  env: {
+    isSubprocess: 'true',
+  },
+});
+
+child.on('message', (data) => {
+  // console.log(data.toString());
+});

--- a/test/memory/issue/issue-199/parent.js
+++ b/test/memory/issue/issue-199/parent.js
@@ -9,3 +9,4 @@ var child = require('child_process').fork(__dirname + '/child.js', {
 child.on('message', (data) => {
   // console.log(data.toString());
 });
+


### PR DESCRIPTION
This fixes #199 which caused by not calling `iotjs_string_destroy()` when buffer write is done.

/cc @lolBig @legendecas 