### PR TITLE
iotjs: fix memory leak

### DIFF
--- a/src/modules/iotjs_module_child_process.c
+++ b/src/modules/iotjs_module_child_process.c
@@ -76,6 +76,7 @@ static void iotjs_processwrap_onexit(uv_process_t* handle, int64_t exit_status,
   if (jerry_value_is_function(fn)) {
     iotjs_make_callback(fn, jthis, &jargs);
   }
+  iotjs_jargs_destroy(&jargs);
   jerry_release_value(status);
   jerry_release_value(signal);
   jerry_release_value(fn);

--- a/src/modules/iotjs_module_child_process.c
+++ b/src/modules/iotjs_module_child_process.c
@@ -76,6 +76,7 @@ static void iotjs_processwrap_onexit(uv_process_t* handle, int64_t exit_status,
   if (jerry_value_is_function(fn)) {
     iotjs_make_callback(fn, jthis, &jargs);
   }
+
   iotjs_jargs_destroy(&jargs);
   jerry_release_value(status);
   jerry_release_value(signal);

--- a/tools/travis_script.py
+++ b/tools/travis_script.py
@@ -27,7 +27,6 @@ BUILDOPTIONS_SANITIZER = [
     '--compile-flag=-fno-omit-frame-pointer',
     '--jerry-cmake-param=-DFEATURE_SYSTEM_ALLOCATOR=ON',
     '--jerry-cmake-param=-DJERRY_LIBC=OFF',
-    '--no-check-valgrind',
     '--no-snapshot',
     '--profile=test/profiles/host-linux.profile',
     '--run-test=full',

--- a/tools/travis_script.py
+++ b/tools/travis_script.py
@@ -80,7 +80,8 @@ if __name__ == '__main__':
         for buildtype in BUILDTYPES:
             build_iotjs(buildtype, [
                         '--cmake-param=-DENABLE_MODULE_ASSERT=ON',
-                        '--tests'])
+                        '--tests',
+                        '--no-check-valgrind'])
 
     elif test == "host-darwin":
         for buildtype in BUILDTYPES:

--- a/tools/travis_script.py
+++ b/tools/travis_script.py
@@ -80,8 +80,7 @@ if __name__ == '__main__':
         for buildtype in BUILDTYPES:
             build_iotjs(buildtype, [
                         '--cmake-param=-DENABLE_MODULE_ASSERT=ON',
-                        '--tests',
-                        '--no-check-valgrind'])
+                        '--tests'])
 
     elif test == "host-darwin":
         for buildtype in BUILDTYPES:

--- a/tools/travis_script.py
+++ b/tools/travis_script.py
@@ -27,6 +27,7 @@ BUILDOPTIONS_SANITIZER = [
     '--compile-flag=-fno-omit-frame-pointer',
     '--jerry-cmake-param=-DFEATURE_SYSTEM_ALLOCATOR=ON',
     '--jerry-cmake-param=-DJERRY_LIBC=OFF',
+    '--no-check-valgrind',
     '--no-snapshot',
     '--profile=test/profiles/host-linux.profile',
     '--run-test=full',


### PR DESCRIPTION
After fix this, valgrind on ubuntu pass all. So --no-check-valgrind can be removed.