### PR TITLE
iotjs: change iotjs_jval_as_string to use utf8 buffers

### DIFF
--- a/src/iotjs_binding.c
+++ b/src/iotjs_binding.c
@@ -117,7 +117,7 @@ double iotjs_jval_as_number(jerry_value_t jval) {
 iotjs_string_t iotjs_jval_as_string(jerry_value_t jval) {
   IOTJS_ASSERT(jerry_value_is_string(jval));
 
-  jerry_size_t size = jerry_get_string_size(jval);
+  jerry_size_t size = jerry_get_utf8_string_size(jval);
 
   if (size == 0)
     return iotjs_string_create();
@@ -125,7 +125,7 @@ iotjs_string_t iotjs_jval_as_string(jerry_value_t jval) {
   char* buffer = iotjs_buffer_allocate(size + 1);
   jerry_char_t* jerry_buffer = (jerry_char_t*)(buffer);
 
-  size_t check = jerry_string_to_char_buffer(jval, jerry_buffer, size);
+  size_t check = jerry_string_to_utf8_char_buffer(jval, jerry_buffer, size);
 
   IOTJS_ASSERT(check == size);
   buffer[size] = '\0';

--- a/test/run_pass/test_console.js
+++ b/test/run_pass/test_console.js
@@ -26,6 +26,7 @@ console.log('a', 1, 'b', 2, 'c', 3);
 console.log('test', null, undefined);
 console.log({ a: '123', b: 123, c: [1, 2, 3] });
 console.log('🎉🦄✨');
+console.log('杭州english');
 
 console.error('Hello IoT.js!!');
 console.error(1);

--- a/test/run_pass/test_console.js
+++ b/test/run_pass/test_console.js
@@ -25,6 +25,7 @@ console.log(1, 2, 3);
 console.log('a', 1, 'b', 2, 'c', 3);
 console.log('test', null, undefined);
 console.log({ a: '123', b: 123, c: [1, 2, 3] });
+console.log('🎉🦄✨');
 
 console.error('Hello IoT.js!!');
 console.error(1);


### PR DESCRIPTION
Upstream commit: https://github.com/Samsung/iotjs/commit/68e84c78c9cee2979831c842e57976ed9ca73ea8.

The detailed case is here: https://github.com/Samsung/iotjs/issues/1562.

/cc @lolBig 