### PR TITLE
events: optimize the performance of emit over 5x

### DIFF
--- a/benchmark/events/emit.js
+++ b/benchmark/events/emit.js
@@ -1,0 +1,19 @@
+'use strict';
+
+var EventEmitter = require('events').EventEmitter;
+var common = require('../common.js');
+var bench = common.createBenchmark(main, {
+  n: [256],
+});
+
+var emitter = new EventEmitter();
+
+function main(opts) {
+  var n = opts.n;
+  bench.start();
+  for (var i = 0; i < n; i += 1)
+    emitter.on('data', () => false);
+  for (var i = 0; i < n; i += 1)
+    emitter.emit('data', 'test');
+  bench.end(n);
+}

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -25,7 +25,7 @@ module.exports = EventEmitter;
 module.exports.EventEmitter = EventEmitter;
 
 
-EventEmitter.prototype.emit = function(type) {
+EventEmitter.prototype.emit = function(type, arg1, arg2) {
   if (!this._events) {
     this._events = {};
   }
@@ -42,8 +42,13 @@ EventEmitter.prototype.emit = function(type) {
 
   var listeners = this._events[type];
   if (util.isArray(listeners)) {
-    listeners = listeners.slice();
-    var args = Array.prototype.slice.call(arguments, 1);
+    var args;
+    switch (arguments.length) {
+      case 0: args = []; break;
+      case 1: args = [arg1]; break;
+      case 2: args = [arg1, arg2]; break;
+      default: args = Array.prototype.slice.call(arguments, 1); break;
+    }
     for (var i = 0; i < listeners.length; ++i) {
       listeners[i].apply(this, args);
     }


### PR DESCRIPTION
Optimize the common case for emit arguments slicing, and the following shows the benchmark results:

```js
// before
$ iotjs benchmark/run.js events

events/emit.js
events/emit.js n=256: 343.92192036295285

// after
iotjs benchmark/run.js events

events/emit.js
events/emit.js n=256: 1,771.9394219594446
```

This optimizes 5x for `emit(name[, arg1, arg2])`.

/cc @lolBig @legendecas 