### PR TITLE
Release Proposal: working on v0.9.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ cmake_minimum_required(VERSION 2.8)
 project(IOTJS C)
 
 set(IOTJS_VERSION_MAJOR 0)
-set(IOTJS_VERSION_MINOR 8)
+set(IOTJS_VERSION_MINOR 9)
 set(IOTJS_VERSION_PATCH 0)
 
 # Do a few default checks

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ShadowNode",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Use Node.js in your embeddable devices",
   "scripts": {
     "lint": "tools/check_tidy.py && eslint .",


### PR DESCRIPTION
Hello @Rokid/nodejs, Let's working on ShadowNode v0.9 now!

In _v0.8.x_, we have 53 commits pushed, 36 Pull Request merged and 30 issues closed. Let's see what changes we have done.

#### JerryScript

- Add `Function.prototype.name` with _FEATURE_FUNCTION_NAME_ #123.
- Add native function `jerry_has_property_by_index()` #139.
- Add CPU Profiler with _FEATURE_CPU_PROFILER_ which supports to generate flamegraph #176.
- Promise: remove native and use the pure javascript implementation #215.
- Record magic string id for builtin objects and routines #160.
- Use tmpfile() for parser dump storage instead a normal file #178.
- Fix uninitialized memory malloced #165.
- Fix test and build warnings #170 #206.

#### Build
  
- Update upstream travis script #157.
- Remove jsdriver and use new Python-based test driver from upstream #208.
- Run lint before starting test #168.
- Add deploy stage in TravisCI for releases #224.
- Migrate the Node.js core benchmark framework into ShadowNode #134.
- A new tool to see which ECMAScript features are supported #212.
- Add [Codacy](https://www.codacy.com/) for source code scan statically.

#### Bootstrap

- Fix the `Math.random()` by generating different seed with `srand()` #138.
- Add `handlewrap_queue` for clean the handlewrap up more clean #144, #164.
- Improve CLI options, more like Node.js #193.

#### Modules

- Buffer
  - Add `writeInt32LE()` #163.
  - Add `writeInt16LE()` #169.
- Process
  - Proper message display for dlopen function #131.
  - Add `process.title` #225.
- Console
  - Optimize the performance for single params #140.
  - Disable stdio buffering which follows Node.js #182.
- Child Process
  - Use `uv_write` to instead of `uv_try_write` to fix EAGAIN with large buffer #223.
  - Leak: destroy the iotjs_args_t object when process exits #203.
  - Leak: free the blocks by strdup() #198.
- Stream
  - Add encoding parameter for `writable#write` #184.
- Net / TLS
  - Use IPv4 as the default DNS family #135.
  - Fix checking for `shundown()` #154.
  - Inherit TLS socket from `net.Socket` #149.
- HTTP / HTTPS
  - Support chunked transfer encoding and by default #174.
  - Set `Content-Length` by body if not set #142.
  - Allow zero value for `Content-Length` #158.
- D-Bus
  - Support multiple arguments for signal events #205.
  - Improve the error message if the caller is invalid #214.
  - Leak: release leaked allocated string and value #226.
- MQTT
  - Remove unused member and spaces #191.

#### Community

- [shadow-node/ffi](https://github.com/shadow-node/ffi): Add-on for loading and calling dynamic library with pure JavaScript.
- a new committer @LanFly.

In _v0.9_, we will focus on:

- Implement the 80% N-API with the following rules:
  - `node.h` must be pulled from Node.js.
  - support backward compatible with the JerryScript modules still.
- Bench: cover and improve the performance `EventEmitter` and other core modules.