### PR TITLE
jerryx: root handle scope convenience methods

### DIFF
--- a/deps/jerry/jerry-ext/handle-scope/handle-scope-allocator.c
+++ b/deps/jerry/jerry-ext/handle-scope/handle-scope-allocator.c
@@ -75,6 +75,10 @@ jerryx_handle_scope_is_in_prelist (jerryx_handle_scope_t *scope)
 jerryx_handle_scope_t *
 jerryx_handle_scope_get_parent (jerryx_handle_scope_t *scope)
 {
+  if (scope == &kJerryXHandleScopeRoot)
+  {
+    return NULL;
+  }
   if (!jerryx_handle_scope_is_in_prelist (scope))
   {
     jerryx_handle_scope_dynamic_t *dy_scope = (jerryx_handle_scope_dynamic_t *) scope;
@@ -87,7 +91,7 @@ jerryx_handle_scope_get_parent (jerryx_handle_scope_t *scope)
   }
   if (scope == kJerryXHandleScopePool.prelist)
   {
-    return NULL;
+    return &kJerryXHandleScopeRoot;
   }
   return kJerryXHandleScopePool.prelist + JerryXHandleScopePrelistIdx (scope) - 1;
 }
@@ -102,6 +106,13 @@ jerryx_handle_scope_get_parent (jerryx_handle_scope_t *scope)
 jerryx_handle_scope_t *
 jerryx_handle_scope_get_child (jerryx_handle_scope_t *scope)
 {
+  if (scope == &kJerryXHandleScopeRoot)
+  {
+    if (kJerryXHandleScopePool.count > 0) {
+      return kJerryXHandleScopePool.prelist;
+    }
+    return NULL;
+  }
   if (!jerryx_handle_scope_is_in_prelist (scope))
   {
     jerryx_handle_scope_dynamic_t *child = ((jerryx_handle_scope_dynamic_t *) scope)->child;
@@ -181,6 +192,11 @@ deferred:
 void
 jerryx_handle_scope_free (jerryx_handle_scope_t *scope)
 {
+  if (scope == &kJerryXHandleScopeRoot)
+  {
+    return;
+  }
+
   kJerryXHandleScopePool.count -= 1;
 
   if (!jerryx_handle_scope_is_in_prelist (scope))

--- a/deps/jerry/jerry-ext/handle-scope/handle-scope-internal.h
+++ b/deps/jerry/jerry-ext/handle-scope/handle-scope-internal.h
@@ -52,12 +52,6 @@ struct jerryx_handle_scope_pool_s {
 };
 
 jerryx_handle_scope_t *
-jerryx_handle_scope_get_current (void);
-
-jerryx_handle_scope_t *
-jerryx_handle_scope_get_root (void);
-
-jerryx_handle_scope_t *
 jerryx_handle_scope_get_parent (jerryx_handle_scope_t *scope);
 
 jerryx_handle_scope_t *

--- a/deps/jerry/jerry-ext/handle-scope/handle-scope.c
+++ b/deps/jerry/jerry-ext/handle-scope/handle-scope.c
@@ -52,6 +52,7 @@ jerryx_handle_scope_release_handles (jerryx_handle_scope scope)
   {
     jerry_release_value (scope->handle_prelist[idx]);
   }
+  scope->handle_count = 0;
 }
 
 

--- a/deps/jerry/jerry-ext/include/jerryscript-ext/handle-scope.h
+++ b/deps/jerry/jerry-ext/include/jerryscript-ext/handle-scope.h
@@ -86,6 +86,15 @@ jerryx_escape_handle (jerryx_escapable_handle_scope scope,
 jerry_value_t
 jerryx_create_handle (jerry_value_t jval);
 
+
+/** MARK: - handle-scope-allocator.c */
+jerryx_handle_scope_t *
+jerryx_handle_scope_get_current (void);
+
+jerryx_handle_scope_t *
+jerryx_handle_scope_get_root (void);
+/** MARK: - END handle-scope-allocator.c */
+
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/deps/jerry/tests/unit-ext/test-ext-handle-scope-root.c
+++ b/deps/jerry/tests/unit-ext/test-ext-handle-scope-root.c
@@ -1,0 +1,74 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Unit test for jerry-ext/handle-scope.
+ */
+
+#include "jerryscript.h"
+#include "jerryscript-ext/handle-scope.h"
+#include "test-common.h"
+
+static int native_free_cb_call_count;
+static int reusing_times = 10;
+
+static void
+native_free_cb (void *native_p)
+{
+  ++native_free_cb_call_count;
+  (void) native_p;
+} /* native_free_cb */
+
+static const jerry_object_native_info_t native_info =
+{
+  .free_cb = native_free_cb,
+};
+
+static jerry_value_t
+create_object (void)
+{
+  jerry_value_t obj = jerry_create_object ();
+  jerry_set_object_native_pointer (obj, NULL, &native_info);
+  return obj;
+} /* create_object */
+
+static void
+test_handle_scope_val (void)
+{
+  jerryx_escapable_handle_scope root = jerryx_handle_scope_get_root ();
+  // root handle scope should always be reusable after close
+  for (int i = 0; i < reusing_times; ++i)
+  {
+    jerry_value_t obj = jerryx_create_handle (create_object ());
+    (void) obj;
+    jerryx_close_handle_scope (root);
+    jerry_gc ();
+    TEST_ASSERT (native_free_cb_call_count == (i + 1));
+  }
+} /* test_handle_scope_val */
+
+int
+main (void)
+{
+  jerry_init (JERRY_INIT_EMPTY);
+
+  native_free_cb_call_count = 0;
+  test_handle_scope_val ();
+
+  jerry_gc ();
+  TEST_ASSERT (native_free_cb_call_count == reusing_times);
+
+  jerry_cleanup ();
+} /* main */


### PR DESCRIPTION
Series convenience methods of root handle scope.

Closes root handle scope on iotjs exit.

- [x] tests
- [x] add jerry-ext dependency to iotjs (#247 )
- [x] build option to include jerryx (#247 )