### PR TITLE
env: check exiting state before set after emit exit event

### DIFF
--- a/src/iotjs.c
+++ b/src/iotjs.c
@@ -163,11 +163,11 @@ static int iotjs_start(iotjs_environment_t* env) {
     } while (more && !iotjs_environment_is_exiting(env));
 
     exit_code = iotjs_process_exitcode();
-
     if (!iotjs_environment_is_exiting(env)) {
       // Emit 'exit' event.
       iotjs_process_emit_exit(exit_code);
-
+    }
+    if (!iotjs_environment_is_exiting(env)) {
       iotjs_environment_go_state_exiting(env);
     }
   }

--- a/test/run_pass/test_process_exit.js
+++ b/test/run_pass/test_process_exit.js
@@ -13,5 +13,4 @@
  * limitations under the License.
  */
 
-
 process.exit(0);

--- a/test/run_pass/test_process_exit_handler.js
+++ b/test/run_pass/test_process_exit_handler.js
@@ -1,0 +1,5 @@
+'use strict';
+
+process.on('exit', function() {
+  process.exit(0)
+});


### PR DESCRIPTION
This fixes the case when we process.exit in the exit handler. To reproduce this case, just run the following code:

```js
process.on('exit', function() {
  process.exit(0)
});
```

Which [shadow-node/tape](https://github.com/shadow-node/tape) is using it, and it gives an assertion error:

```
$ /Users/yorkieliu/workspace/shadow-node/src/iotjs_env.c:286: Assertion '_this->state < kExiting' failed.
```

This is because:

- Emit `exit` handler
- Call `process.exit()` in handler, this makes `state` to be `kExiting`.
- Call `iotjs_environment_go_state_exiting()`
  - Failed on assertion because the state is not less than `kExiting`.

To fix this problem, just check the global state is `kExiting` before `go_state_exiting()` always.