### PR TITLE
handle-scope: complete escaping of handles

### DIFF
--- a/deps/jerry/jerry-ext/handle-scope/handle-scope-internal.h
+++ b/deps/jerry/jerry-ext/handle-scope/handle-scope-internal.h
@@ -76,6 +76,12 @@ jerryx_handle_scope_add_handle_to (jerryx_handle_t *handle, jerryx_handle_scope 
 
 void
 jerryx_create_handle_in_scope (jerry_value_t jval, jerryx_handle_scope scope);
+
+jerryx_handle_scope_status
+jerryx_escape_handle_impl (jerryx_escapable_handle_scope scope,
+                           jerry_value_t escapee,
+                           jerry_value_t *result,
+                           bool should_promote);
 /** MARK: - END handle-scope.c */
 
 #ifdef __cplusplus

--- a/deps/jerry/jerry-ext/handle-scope/handle-scope-internal.h
+++ b/deps/jerry/jerry-ext/handle-scope/handle-scope-internal.h
@@ -78,7 +78,7 @@ void
 jerryx_create_handle_in_scope (jerry_value_t jval, jerryx_handle_scope scope);
 
 jerryx_handle_scope_status
-jerryx_escape_handle_impl (jerryx_escapable_handle_scope scope,
+jerryx_escape_handle_internal (jerryx_escapable_handle_scope scope,
                            jerry_value_t escapee,
                            jerry_value_t *result,
                            bool should_promote);

--- a/deps/jerry/jerry-ext/handle-scope/handle-scope-internal.h
+++ b/deps/jerry/jerry-ext/handle-scope/handle-scope-internal.h
@@ -79,9 +79,9 @@ jerryx_create_handle_in_scope (jerry_value_t jval, jerryx_handle_scope scope);
 
 jerryx_handle_scope_status
 jerryx_escape_handle_internal (jerryx_escapable_handle_scope scope,
-                           jerry_value_t escapee,
-                           jerry_value_t *result,
-                           bool should_promote);
+                               jerry_value_t escapee,
+                               jerry_value_t *result,
+                               bool should_promote);
 /** MARK: - END handle-scope.c */
 
 #ifdef __cplusplus

--- a/deps/jerry/jerry-ext/handle-scope/handle-scope.c
+++ b/deps/jerry/jerry-ext/handle-scope/handle-scope.c
@@ -268,7 +268,7 @@ jerryx_escape_handle (jerryx_escapable_handle_scope scope,
  * @return status code, jerryx_handle_scope_ok if success.
  */
 jerryx_handle_scope_status
-jerry_remove_handle (jerryx_escapable_handle_scope scope,
+jerryx_remove_handle (jerryx_escapable_handle_scope scope,
                      jerry_value_t escapee,
                      jerry_value_t *result)
 {

--- a/deps/jerry/jerry-ext/handle-scope/handle-scope.c
+++ b/deps/jerry/jerry-ext/handle-scope/handle-scope.c
@@ -269,8 +269,8 @@ jerryx_escape_handle (jerryx_escapable_handle_scope scope,
  */
 jerryx_handle_scope_status
 jerryx_remove_handle (jerryx_escapable_handle_scope scope,
-                     jerry_value_t escapee,
-                     jerry_value_t *result)
+                      jerry_value_t escapee,
+                      jerry_value_t *result)
 {
   return jerryx_escape_handle_internal (scope, escapee, result, false);
 }

--- a/deps/jerry/jerry-ext/handle-scope/handle-scope.c
+++ b/deps/jerry/jerry-ext/handle-scope/handle-scope.c
@@ -268,7 +268,7 @@ jerryx_escape_handle (jerryx_escapable_handle_scope scope,
  * @return status code, jerryx_handle_scope_ok if success.
  */
 jerryx_handle_scope_status
-jerryx_evade_handle (jerryx_escapable_handle_scope scope,
+jerry_remove_handle (jerryx_escapable_handle_scope scope,
                      jerry_value_t escapee,
                      jerry_value_t *result)
 {

--- a/deps/jerry/jerry-ext/handle-scope/handle-scope.c
+++ b/deps/jerry/jerry-ext/handle-scope/handle-scope.c
@@ -136,10 +136,10 @@ jerryx_hand_scope_escape_handle_from_prelist (jerryx_handle_scope scope, size_t 
 
 
 jerryx_handle_scope_status
-jerryx_escape_handle_impl (jerryx_escapable_handle_scope scope,
-                           jerry_value_t escapee,
-                           jerry_value_t *result,
-                           bool should_promote)
+jerryx_escape_handle_internal (jerryx_escapable_handle_scope scope,
+                               jerry_value_t escapee,
+                               jerry_value_t *result,
+                               bool should_promote)
 {
   if (scope->escaped)
   {
@@ -257,7 +257,7 @@ jerryx_escape_handle (jerryx_escapable_handle_scope scope,
                       jerry_value_t escapee,
                       jerry_value_t *result)
 {
-  return jerryx_escape_handle_impl(scope, escapee, result, true);
+  return jerryx_escape_handle_internal (scope, escapee, result, true);
 }
 
 
@@ -272,7 +272,7 @@ jerry_remove_handle (jerryx_escapable_handle_scope scope,
                      jerry_value_t escapee,
                      jerry_value_t *result)
 {
-  return jerryx_escape_handle_impl(scope, escapee, result, false);
+  return jerryx_escape_handle_internal (scope, escapee, result, false);
 }
 
 

--- a/deps/jerry/jerry-ext/include/jerryscript-ext/handle-scope.h
+++ b/deps/jerry/jerry-ext/include/jerryscript-ext/handle-scope.h
@@ -89,8 +89,8 @@ jerryx_escape_handle (jerryx_escapable_handle_scope scope,
  */
 jerryx_handle_scope_status
 jerryx_remove_handle (jerryx_escapable_handle_scope scope,
-                     jerry_value_t escapee,
-                     jerry_value_t *result);
+                      jerry_value_t escapee,
+                      jerry_value_t *result);
 
 jerry_value_t
 jerryx_create_handle (jerry_value_t jval);

--- a/deps/jerry/jerry-ext/include/jerryscript-ext/handle-scope.h
+++ b/deps/jerry/jerry-ext/include/jerryscript-ext/handle-scope.h
@@ -83,6 +83,15 @@ jerryx_escape_handle (jerryx_escapable_handle_scope scope,
                       jerry_value_t escapee,
                       jerry_value_t *result);
 
+/**
+ * Completely escape a handle from handle scope,
+ * leave life time management totally up to user.
+ */
+jerryx_handle_scope_status
+jerryx_evade_handle (jerryx_escapable_handle_scope scope,
+                     jerry_value_t escapee,
+                     jerry_value_t *result);
+
 jerry_value_t
 jerryx_create_handle (jerry_value_t jval);
 

--- a/deps/jerry/jerry-ext/include/jerryscript-ext/handle-scope.h
+++ b/deps/jerry/jerry-ext/include/jerryscript-ext/handle-scope.h
@@ -88,7 +88,7 @@ jerryx_escape_handle (jerryx_escapable_handle_scope scope,
  * leave life time management totally up to user.
  */
 jerryx_handle_scope_status
-jerryx_evade_handle (jerryx_escapable_handle_scope scope,
+jerry_remove_handle (jerryx_escapable_handle_scope scope,
                      jerry_value_t escapee,
                      jerry_value_t *result);
 

--- a/deps/jerry/jerry-ext/include/jerryscript-ext/handle-scope.h
+++ b/deps/jerry/jerry-ext/include/jerryscript-ext/handle-scope.h
@@ -88,7 +88,7 @@ jerryx_escape_handle (jerryx_escapable_handle_scope scope,
  * leave life time management totally up to user.
  */
 jerryx_handle_scope_status
-jerry_remove_handle (jerryx_escapable_handle_scope scope,
+jerryx_remove_handle (jerryx_escapable_handle_scope scope,
                      jerry_value_t escapee,
                      jerry_value_t *result);
 

--- a/deps/jerry/tests/unit-ext/test-ext-handle-scope-evade.c
+++ b/deps/jerry/tests/unit-ext/test-ext-handle-scope-evade.c
@@ -1,0 +1,84 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Unit test for jerry-ext/handle-scope.
+ */
+
+#include "jerryscript.h"
+#include "jerryscript-ext/handle-scope.h"
+#include "test-common.h"
+
+static int native_free_cb_call_count;
+
+static void
+native_free_cb (void *native_p)
+{
+  ++native_free_cb_call_count;
+  (void) native_p;
+} /* native_free_cb */
+
+static const jerry_object_native_info_t native_info =
+{
+  .free_cb = native_free_cb,
+};
+
+static jerry_value_t
+create_object (void)
+{
+  jerryx_escapable_handle_scope scope;
+  jerryx_open_escapable_handle_scope (&scope);
+  jerry_value_t obj = jerryx_create_handle (jerry_create_object ());
+  jerry_set_object_native_pointer (obj, NULL, &native_info);
+
+  // If leaves `escaped` uninitialized, there will be a style error on linux thrown by compiler
+  jerry_value_t escaped = 0;
+  jerryx_evade_handle (scope, obj, &escaped);
+  TEST_ASSERT (scope->handle_count == 0);
+
+  jerryx_close_handle_scope (scope);
+  return escaped;
+} /* create_object */
+
+static void
+test_handle_scope_val (void)
+{
+  jerryx_handle_scope scope;
+  jerryx_open_handle_scope (&scope);
+  jerry_value_t obj = create_object ();
+  (void) obj;
+
+  jerry_gc();
+  TEST_ASSERT (native_free_cb_call_count == 0);
+
+  jerryx_close_handle_scope (scope);
+  jerry_gc ();
+  TEST_ASSERT (native_free_cb_call_count == 0);
+
+  jerry_release_value (obj);
+  jerry_gc ();
+  TEST_ASSERT (native_free_cb_call_count == 1);
+} /* test_handle_scope_val */
+
+int
+main (void)
+{
+  jerry_init (JERRY_INIT_EMPTY);
+
+  native_free_cb_call_count = 0;
+  test_handle_scope_val ();
+
+  jerry_cleanup ();
+} /* main */

--- a/deps/jerry/tests/unit-ext/test-ext-handle-scope-remove.c
+++ b/deps/jerry/tests/unit-ext/test-ext-handle-scope-remove.c
@@ -45,7 +45,7 @@ create_object (void)
 
   // If leaves `escaped` uninitialized, there will be a style error on linux thrown by compiler
   jerry_value_t escaped = 0;
-  jerryx_evade_handle (scope, obj, &escaped);
+  jerry_remove_handle (scope, obj, &escaped);
   TEST_ASSERT (scope->handle_count == 0);
 
   jerryx_close_handle_scope (scope);

--- a/deps/jerry/tests/unit-ext/test-ext-handle-scope-remove.c
+++ b/deps/jerry/tests/unit-ext/test-ext-handle-scope-remove.c
@@ -45,7 +45,7 @@ create_object (void)
 
   // If leaves `escaped` uninitialized, there will be a style error on linux thrown by compiler
   jerry_value_t escaped = 0;
-  jerry_remove_handle (scope, obj, &escaped);
+  jerryx_remove_handle (scope, obj, &escaped);
   TEST_ASSERT (scope->handle_count == 0);
 
   jerryx_close_handle_scope (scope);

--- a/src/napi/node_api_module.c
+++ b/src/napi/node_api_module.c
@@ -52,12 +52,7 @@ int napi_module_init_pending(jerry_value_t *exports) {
     if (jval_ret != jval_exports) {
       jerry_release_value(jval_exports);
     }
-    /**
-     * TODO: how do root scope cope with JS_FUNCTION
-     * return value's auto-releasing?
-     */
-    jerry_acquire_value(jval_ret);
-    jerryx_escape_handle(scope, jval_ret, exports);
+    jerryx_evade_handle(scope, jval_ret, exports);
   }
 
   jerryx_close_handle_scope(scope);

--- a/src/napi/node_api_module.c
+++ b/src/napi/node_api_module.c
@@ -52,7 +52,7 @@ int napi_module_init_pending(jerry_value_t *exports) {
     if (jval_ret != jval_exports) {
       jerry_release_value(jval_exports);
     }
-    jerry_remove_handle(scope, jval_ret, exports);
+    jerryx_remove_handle(scope, jval_ret, exports);
   }
 
   jerryx_close_handle_scope(scope);

--- a/src/napi/node_api_module.c
+++ b/src/napi/node_api_module.c
@@ -52,7 +52,7 @@ int napi_module_init_pending(jerry_value_t *exports) {
     if (jval_ret != jval_exports) {
       jerry_release_value(jval_exports);
     }
-    jerryx_evade_handle(scope, jval_ret, exports);
+    jerry_remove_handle(scope, jval_ret, exports);
   }
 
   jerryx_close_handle_scope(scope);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added

There may be some handles we have to hand over it's life time management to jerry engine, and totally give up it's reference. Rather escaping it and keep a ref to the value in parent scope, the reference shall be deleted from the scope.