### PR TITLE
DBus: fix require crash

### DIFF
--- a/src/modules/iotjs_module_dbus.c
+++ b/src/modules/iotjs_module_dbus.c
@@ -684,6 +684,5 @@ jerry_value_t InitDBus() {
 
   jerry_release_value(proto);
   jerry_release_value(jdbusConstructor);
-  jerry_release_value(jdbus);
   return jdbus;
 }


### PR DESCRIPTION
fix crash caused by release jdbus while require dbus module