### PR TITLE
napi: working with javascript values

### DIFF
--- a/src/internal/node_api_internal.h
+++ b/src/internal/node_api_internal.h
@@ -31,7 +31,6 @@
       return error_t;                        \
   } while (0)
 
-
 #define NAPI_TRY_TYPE(type, jval) \
   NAPI_WEAK_ASSERT(napi_##type##_expected, jerry_value_is_##type(jval))
 
@@ -47,6 +46,10 @@
       return status;             \
     }                            \
   } while (0)
+
+#define JERRYX_CREATE(var, create) \
+  jerry_value_t var = create;      \
+  jerryx_create_handle(var);
 
 /** MARK: - node_api_module.c */
 int napi_module_init_pending(jerry_value_t *exports);

--- a/src/napi/node_api_value.c
+++ b/src/napi/node_api_value.c
@@ -141,20 +141,20 @@ napi_status napi_typeof(napi_env env, napi_value value,
   jerry_value_t jval = AS_JERRY_VALUE(value);
   jerry_type_t type = jerry_value_get_type(jval);
 
-#define CM(jerry, napi) \
-  case jerry:           \
-    *result = napi;     \
+#define MAP(jerry, napi) \
+  case jerry:            \
+    *result = napi;      \
     break;
 
   switch (type) {
-    CM(JERRY_TYPE_UNDEFINED, napi_undefined);
-    CM(JERRY_TYPE_NULL, napi_null);
-    CM(JERRY_TYPE_BOOLEAN, napi_boolean);
-    CM(JERRY_TYPE_NUMBER, napi_number);
-    CM(JERRY_TYPE_STRING, napi_string);
-    CM(JERRY_TYPE_OBJECT, napi_object);
-    CM(JERRY_TYPE_FUNCTION, napi_function);
-#undef CM
+    MAP(JERRY_TYPE_UNDEFINED, napi_undefined);
+    MAP(JERRY_TYPE_NULL, napi_null);
+    MAP(JERRY_TYPE_BOOLEAN, napi_boolean);
+    MAP(JERRY_TYPE_NUMBER, napi_number);
+    MAP(JERRY_TYPE_STRING, napi_string);
+    MAP(JERRY_TYPE_OBJECT, napi_object);
+    MAP(JERRY_TYPE_FUNCTION, napi_function);
+#undef MAP
     default:
       return napi_invalid_arg;
   }

--- a/src/napi/node_api_value.c
+++ b/src/napi/node_api_value.c
@@ -171,5 +171,14 @@ napi_status napi_typeof(napi_env env, napi_value value,
 
 DEF_NAPI_VALUE_IS(array);
 DEF_NAPI_VALUE_IS(arraybuffer);
-DEF_NAPI_VALUE_IS(error);
 DEF_NAPI_VALUE_IS(typedarray);
+
+napi_status napi_is_error(napi_env env, napi_value value, bool* result) {
+  jerry_value_t jval = AS_JERRY_VALUE(value);
+  /**
+   * TODO: Pick jerrysciprt#ba2e49caaa6703dec7a83fb0b8586a91fac060eb to use
+   * function `jerry_value_is_error`
+   */
+  *result = jerry_value_has_error_flag(jval);
+  return napi_ok;
+}

--- a/src/napi/node_api_value.c
+++ b/src/napi/node_api_value.c
@@ -17,6 +17,25 @@
 #include "jerryscript.h"
 #include "internal/node_api_internal.h"
 
+napi_status napi_create_array(napi_env env, napi_value* result) {
+  JERRYX_CREATE(jval, jerry_create_array(0));
+  *result = AS_NAPI_VALUE(jval);
+  return napi_ok;
+}
+
+napi_status napi_create_array_with_length(napi_env env, size_t length,
+                                          napi_value* result) {
+  JERRYX_CREATE(jval, jerry_create_array(length));
+  *result = AS_NAPI_VALUE(jval);
+  return napi_ok;
+}
+
+napi_status napi_create_object(napi_env env, napi_value* result) {
+  JERRYX_CREATE(jval, jerry_create_object());
+  *result = AS_NAPI_VALUE(jval);
+  return napi_ok;
+}
+
 #define DEF_NAPI_NUMBER_CONVERT_FROM_C_TYPE(type, name)      \
   napi_status napi_create_##name(napi_env env, type value,   \
                                  napi_value* result) {       \
@@ -55,3 +74,102 @@ napi_status napi_create_string_utf8(napi_env env, const char* str,
   *result = AS_NAPI_VALUE(jval);
   return napi_ok;
 }
+
+napi_status napi_get_array_length(napi_env env, napi_value value,
+                                  uint32_t* result) {
+  jerry_value_t jval = AS_JERRY_VALUE(value);
+  *result = jerry_get_array_length(jval);
+  return napi_ok;
+}
+
+napi_status napi_get_prototype(napi_env env, napi_value object,
+                               napi_value* result) {
+  jerry_value_t jval = AS_JERRY_VALUE(object);
+  jerry_value_t jval_proto = jerry_get_prototype(jval);
+  *result = AS_NAPI_VALUE(jval_proto);
+  return napi_ok;
+}
+
+napi_status napi_get_value_bool(napi_env env, napi_value value, bool* result) {
+  jerry_value_t jval = AS_JERRY_VALUE(value);
+  if (!jerry_value_is_boolean(jval))
+    return napi_boolean_expected;
+  *result = jerry_get_boolean_value(jval);
+  return napi_ok;
+}
+
+napi_status napi_get_boolean(napi_env env, bool value, napi_value* result) {
+  JERRYX_CREATE(jval, jerry_create_boolean(value));
+  *result = AS_NAPI_VALUE(jval);
+  return napi_ok;
+}
+
+napi_status napi_get_global(napi_env env, napi_value* result) {
+  JERRYX_CREATE(jval, jerry_get_global_object());
+  *result = AS_NAPI_VALUE(jval);
+  return napi_ok;
+}
+
+napi_status napi_get_null(napi_env env, napi_value* result) {
+  JERRYX_CREATE(jval, jerry_create_null());
+  *result = AS_NAPI_VALUE(jval);
+  return napi_ok;
+}
+
+napi_status napi_get_undefined(napi_env env, napi_value* result) {
+  JERRYX_CREATE(jval, jerry_create_undefined());
+  *result = AS_NAPI_VALUE(jval);
+  return napi_ok;
+}
+
+#define DEF_NAPI_COERCE_TO(type, alias)                             \
+  napi_status napi_coerce_to_##type(napi_env env, napi_value value, \
+                                    napi_value* result) {           \
+    jerry_value_t jval = AS_JERRY_VALUE(value);                     \
+    jerry_value_t jval_result = jerry_value_to_##alias(jval);       \
+    *result = AS_NAPI_VALUE(jval_result);                           \
+    return napi_ok;                                                 \
+  }
+
+DEF_NAPI_COERCE_TO(bool, boolean);
+DEF_NAPI_COERCE_TO(number, number);
+DEF_NAPI_COERCE_TO(object, object);
+DEF_NAPI_COERCE_TO(string, string);
+
+napi_status napi_typeof(napi_env env, napi_value value,
+                        napi_valuetype* result) {
+  jerry_value_t jval = AS_JERRY_VALUE(value);
+  jerry_type_t type = jerry_value_get_type(jval);
+
+#define CM(jerry, napi) \
+  case jerry:           \
+    *result = napi;     \
+    break;
+
+  switch (type) {
+    CM(JERRY_TYPE_UNDEFINED, napi_undefined);
+    CM(JERRY_TYPE_NULL, napi_null);
+    CM(JERRY_TYPE_BOOLEAN, napi_boolean);
+    CM(JERRY_TYPE_NUMBER, napi_number);
+    CM(JERRY_TYPE_STRING, napi_string);
+    CM(JERRY_TYPE_OBJECT, napi_object);
+    CM(JERRY_TYPE_FUNCTION, napi_function);
+#undef CM
+    default:
+      return napi_invalid_arg;
+  }
+
+  return napi_ok;
+}
+
+#define DEF_NAPI_VALUE_IS(type)                                              \
+  napi_status napi_is_##type(napi_env env, napi_value value, bool* result) { \
+    jerry_value_t jval = AS_JERRY_VALUE(value);                              \
+    *result = jerry_value_is_##type(jval);                                   \
+    return napi_ok;                                                          \
+  }
+
+DEF_NAPI_VALUE_IS(array);
+DEF_NAPI_VALUE_IS(arraybuffer);
+DEF_NAPI_VALUE_IS(error);
+DEF_NAPI_VALUE_IS(typedarray);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added

N-API methods included in this PR:

## Working with JavaScript Values

### Object Creation Functions

- napi_create_array
- napi_create_array_with_length
- napi_create_object

### Functions to convert from N-API to C types

- napi_get_array_length
- napi_get_prototype
- napi_get_value_bool

### Functions to get global instances

- napi_get_boolean
- napi_get_global
- napi_get_null
- napi_get_undefined

## Working with JavaScript Values - Abstract Operations

- napi_coerce_to_bool
- napi_coerce_to_number
- napi_coerce_to_object
- napi_coerce_to_string
- napi_typeof
- napi_is_array
- napi_is_arraybuffer
- napi_is_error
- napi_is_typedarray
