### PR TITLE
module: optimize the compile, direct to read the source

### DIFF
--- a/benchmark/module/compile-from-source.js
+++ b/benchmark/module/compile-from-source.js
@@ -1,0 +1,18 @@
+'use strict';
+
+var common = require('../common.js');
+var path = require('path');
+var bench = common.createBenchmark(main, {
+  n: [512],
+});
+
+function main(opts) {
+  var n = opts.n;
+  var filename = path.join(__dirname, '../common.js');
+
+  bench.start();
+  for (var i = 0; i < n; ++i) {
+    process.compile(filename);
+  }
+  bench.end(n);
+}

--- a/src/js/module.js
+++ b/src/js/module.js
@@ -247,8 +247,7 @@ iotjs_module_t.prototype.compile = function(snapshot) {
   var __dirname = path.dirname(__filename);
   var fn;
   if (!snapshot) {
-    var source = process.readSource(__filename);
-    fn = process.compile(__filename, source);
+    fn = process.compile(__filename);
   } else {
     fn = process.compileSnapshot(__filename);
     if (typeof fn !== 'function')


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added

This directs to read the source inside the compile function, which in anyway decreases the objects in JerryScript, even thought the benchmark are not obvious.