### PR TITLE
module: optimize the path searching

### DIFF
--- a/docs/api/Module.md
+++ b/docs/api/Module.md
@@ -29,10 +29,10 @@ If a native module named `id` exists, load it and return.
 
 `require` function searches for modules in the following order:
 
-1. Current working directory.
-2. `iotjs_modules` folder under current working directory.
-3. `$HOME/iotjs_modules`
-4. `$IOTJS_PATH/iotjs_modules`
+1. `$NODE_PRIORITIZED_PATH/node_modules` if present.
+1. `node_modules` folder under current working directory.
+2. `$NODE_PATH/node_modules`.
+3. `$HOME/node_modules`.
 
 For each directory in search paths above:
 

--- a/docs/api/Module.md
+++ b/docs/api/Module.md
@@ -29,10 +29,10 @@ If a native module named `id` exists, load it and return.
 
 `require` function searches for modules in the following order:
 
-1. `$NODE_PRIORITIZED_PATH/node_modules` if present.
-1. `node_modules` folder under current working directory.
-2. `$NODE_PATH/node_modules`.
-3. `$HOME/node_modules`.
+1. `$NODE_PRIORITIZED_PATH` if present.
+2. `node_modules` folder under current working directory.
+3. `$NODE_PATH` if present.
+4. `$HOME/node_modules`.
 
 For each directory in search paths above:
 

--- a/src/js/module.js
+++ b/src/js/module.js
@@ -47,13 +47,13 @@ try {
 
 var moduledirs = [];
 if (process.env.NODE_PRIORITIZED_PATH) {
-  moduledirs.push(`${process.env.NODE_PRIORITIZED_PATH}/node_modules`);
+  moduledirs.push(process.env.NODE_PRIORITIZED_PATH);
 }
 if (cwd) {
   moduledirs.push(`${cwd}/node_modules/`);
 }
 if (process.env.NODE_PATH) {
-  moduledirs.push(`${process.env.NODE_PATH}/node_modules/`);
+  moduledirs.push(process.env.NODE_PATH);
 }
 if (process.env.HOME) {
   moduledirs.push(`${process.env.HOME}/node_modules/`);

--- a/src/js/module.js
+++ b/src/js/module.js
@@ -47,13 +47,13 @@ try {
 
 var moduledirs = [];
 if (process.env.NODE_PRIORITIZED_PATH) {
-  moduledirs.push(process.env.NODE_PRIORITIZED_PATH);
+  moduledirs.push(`${process.env.NODE_PRIORITIZED_PATH}/`);
 }
 if (cwd) {
   moduledirs.push(`${cwd}/node_modules/`);
 }
 if (process.env.NODE_PATH) {
-  moduledirs.push(process.env.NODE_PATH);
+  moduledirs.push(`${process.env.NODE_PATH}/`);
 }
 if (process.env.HOME) {
   moduledirs.push(`${process.env.HOME}/node_modules/`);
@@ -160,17 +160,20 @@ iotjs_module_t.resolveModPath = function(id, parent) {
   }
 
   var filepath = false;
-  if (id[0] === '.' && parent) {
+  if (id[0] === '/') {
+    filepath = iotjs_module_t._resolveFilepath(id, false);
+  } else if (parent === null) {
+    filepath = iotjs_module_t._resolveFilepath(id, cwd);
+  } else if (id[0] === '.') {
     var root = path.dirname(parent.filename);
     filepath = iotjs_module_t._resolveFilepath(id, root);
-  } else if (id[0] === '/') {
-    filepath = iotjs_module_t._resolveFilepath(id, false);
   } else {
     var dirs = iotjs_module_t.resolveDirectories(id, parent);
     filepath = iotjs_module_t.resolveFilepath(id, dirs);
   }
 
-  if (filepath.indexOf('./') > 0 || filepath.indexOf('../') > 0) {
+  if (filepath &&
+    (filepath.indexOf('./') > 0 || filepath.indexOf('../') > 0)) {
     return iotjs_module_t.normalizePath(filepath);
   }
   return filepath;

--- a/src/js/module.js
+++ b/src/js/module.js
@@ -45,16 +45,18 @@ try {
   cwd = process.cwd();
 } catch (e) { }
 
-var moduledirs = [''];
-if (process.env.NODE_PATH) {
-  moduledirs.push(process.env.NODE_PATH + '/node_modules/');
-}
-if (process.env.HOME) {
-  moduledirs.push(process.env.HOME + '/node_modules/');
+var moduledirs = [];
+if (process.env.NODE_PRIORITIZED_PATH) {
+  moduledirs.push(`${process.env.NODE_PRIORITIZED_PATH}/node_modules`);
 }
 if (cwd) {
-  moduledirs.push(cwd + '/');
-  moduledirs.push(cwd + '/node_modules/');
+  moduledirs.push(`${cwd}/node_modules/`);
+}
+if (process.env.NODE_PATH) {
+  moduledirs.push(`${process.env.NODE_PATH}/node_modules/`);
+}
+if (process.env.HOME) {
+  moduledirs.push(`${process.env.HOME}/node_modules/`);
 }
 
 function tryPath(modulePath, ext) {

--- a/src/js/module.js
+++ b/src/js/module.js
@@ -46,25 +46,37 @@ try {
 } catch (e) { }
 
 var moduledirs = [''];
-if (cwd) {
-  moduledirs.push(cwd + '/');
-  moduledirs.push(cwd + '/node_modules/');
+if (process.env.NODE_PATH) {
+  moduledirs.push(process.env.NODE_PATH + '/node_modules/');
 }
 if (process.env.HOME) {
   moduledirs.push(process.env.HOME + '/node_modules/');
 }
-if (process.env.NODE_PATH) {
-  moduledirs.push(process.env.NODE_PATH + '/node_modules/');
+if (cwd) {
+  moduledirs.push(cwd + '/');
+  moduledirs.push(cwd + '/node_modules/');
 }
 
 function tryPath(modulePath, ext) {
-  return iotjs_module_t.tryPath(modulePath) ||
-         iotjs_module_t.tryPath(modulePath + ext + 'c') ||
-         iotjs_module_t.tryPath(modulePath + ext);
+  return iotjs_module_t.tryPath(modulePath + ext) ||
+         iotjs_module_t.tryPath(modulePath);
 }
 
+
+iotjs_module_t.tryPath = function(path) {
+  try {
+    var stats = fs.statSync(path);
+    if (stats && !stats.isDirectory()) {
+      return path;
+    }
+  } catch (ex) { }
+
+  return false;
+};
+
+
 iotjs_module_t.resolveDirectories = function(id, parent) {
-  var dirs = Object.assign([], moduledirs);
+  var dirs = [];
   if (parent) {
     var start = path.dirname(parent.filename);
     var parts = start.split('/');
@@ -75,6 +87,7 @@ iotjs_module_t.resolveDirectories = function(id, parent) {
       parts.length = parts.length - 1;
     } while (parts.length > 0);
   }
+  dirs = dirs.concat(moduledirs);
 
   if (parent) {
     if (!parent.dirs) {
@@ -100,39 +113,42 @@ iotjs_module_t.resolveFilepath = function(id, directories) {
       modulePath = iotjs_module_t.normalizePath(modulePath);
     }
 
-    var filepath;
-    var ext = '.js';
-
-    // id[.ext]
-    if (filepath = tryPath(modulePath, ext)) {
-      return filepath;
-    }
-
-    if (filepath = tryPath(modulePath + '/index', ext)) {
-      return filepath;
-    }
-
-    // 3. package path id/
-    var jsonpath = modulePath + '/package.json';
-    filepath = iotjs_module_t.tryPath(jsonpath);
+    var filepath = this._resolveFilepath(modulePath, false);
     if (filepath) {
-      var pkgSrc = process.readSource(jsonpath);
-      var pkgMainFile = JSON.parse(pkgSrc).main;
-
-      // pkgmain[.ext]
-      if (filepath = tryPath(modulePath + '/' + pkgMainFile, ext)) {
-        return filepath;
-      }
-
-      // index[.ext] as default
-      if (filepath = tryPath(modulePath + '/index', ext)) {
-        return filepath;
-      }
+      return filepath;
     }
+  }
+  return false;
+};
 
+
+iotjs_module_t._resolveFilepath = function(id, root) {
+  var modulePath = root ? path.join(root, id) : id;
+  var filepath;
+  var ext = '.js';
+
+  // id[.ext]
+  if (filepath = tryPath(modulePath, ext)) {
+    return filepath;
   }
 
-  return false;
+  // id/index[.ext]
+  if (filepath = tryPath(modulePath + '/index', ext)) {
+    return filepath;
+  }
+
+  // 3. package path id/
+  var jsonpath = modulePath + '/package.json';
+  filepath = iotjs_module_t.tryPath(jsonpath);
+  if (filepath) {
+    var pkgSrc = process.readSource(jsonpath);
+    var pkgMainFile = JSON.parse(pkgSrc).main;
+
+    // pkgmain[.ext]
+    if (filepath = tryPath(modulePath + '/' + pkgMainFile, ext)) {
+      return filepath;
+    }
+  }
 };
 
 
@@ -141,15 +157,21 @@ iotjs_module_t.resolveModPath = function(id, parent) {
     return false;
   }
 
-  // 0. resolve Directory for lookup
-  var directories = iotjs_module_t.resolveDirectories(id, parent);
-  var filepath = iotjs_module_t.resolveFilepath(id, directories);
-
-  if (filepath) {
-    return iotjs_module_t.normalizePath(filepath);
+  var filepath = false;
+  if (id[0] === '.' && parent) {
+    var root = path.dirname(parent.filename);
+    filepath = iotjs_module_t._resolveFilepath(id, root);
+  } else if (id[0] === '/') {
+    filepath = iotjs_module_t._resolveFilepath(id, false);
+  } else {
+    var dirs = iotjs_module_t.resolveDirectories(id, parent);
+    filepath = iotjs_module_t.resolveFilepath(id, dirs);
   }
 
-  return false;
+  if (filepath.indexOf('./') > 0 || filepath.indexOf('../') > 0) {
+    return iotjs_module_t.normalizePath(filepath);
+  }
+  return filepath;
 };
 
 
@@ -181,25 +203,12 @@ iotjs_module_t.normalizePath = function(path) {
 };
 
 
-iotjs_module_t.tryPath = function(path) {
-  try {
-    var stats = fs.statSync(path);
-    if (stats && !stats.isDirectory()) {
-      return path;
-    }
-  } catch (ex) { }
-
-  return false;
-};
-
-
 iotjs_module_t.load = function(id, parent) {
   if (process.builtin_modules[id]) {
     iotjs_module_t.curr = id;
     return Native.require(id);
   }
   var module = new iotjs_module_t(id, parent);
-
   var modPath = iotjs_module_t.resolveModPath(module.id, module.parent);
 
   var cachedModule = iotjs_module_t.cache[modPath];
@@ -212,7 +221,12 @@ iotjs_module_t.load = function(id, parent) {
     throw new Error('Module not found: ' + id);
   }
 
-  var startAt = Date.now();
+  var stat = process._loadstat();
+  var startedAt;
+  if (stat) {
+    startedAt = Date.now();
+  }
+
   module.filename = modPath;
   module.dirs = [modPath.substring(0, modPath.lastIndexOf('/') + 1)];
   iotjs_module_t.cache[modPath] = module;
@@ -232,11 +246,10 @@ iotjs_module_t.load = function(id, parent) {
     module.compile();
   }
 
-  if (process._loadstat()) {
-    var endAt = new Date();
+  if (stat) {
     var relPath = modPath.replace(cwd, '');
-    var consume = Math.floor(endAt - startAt);
-    console.log(`[${endAt}] load "${relPath}" ${consume}ms`);
+    var consume = Math.floor(Date.now() - startedAt);
+    console.log(`load "${relPath}" ${consume}ms`);
   }
   return module.exports;
 };

--- a/test/node/parallel/test-assert.js
+++ b/test/node/parallel/test-assert.js
@@ -35,7 +35,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('node/common');
+require('../common');
 
 var assert = require('assert');
 var a = require('assert');

--- a/test/node/parallel/test-http-catch-uncaughtexception.js
+++ b/test/node/parallel/test-http-catch-uncaughtexception.js
@@ -36,7 +36,7 @@
 
 'use strict';
 
-var common = require('node/common');
+var common = require('../common');
 var assert = require('assert');
 var http = require('http');
 

--- a/test/node/parallel/test-http-status-message.js
+++ b/test/node/parallel/test-http-status-message.js
@@ -36,7 +36,7 @@
 
 'use strict';
 
-require('node/common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 var net = require('net');

--- a/test/node/parallel/test-http-write-head.js
+++ b/test/node/parallel/test-http-write-head.js
@@ -36,7 +36,7 @@
 
 'use strict';
 
-var common = require('node/common');
+var common = require('../common');
 var assert = require('assert');
 var http = require('http');
 

--- a/test/node/parallel/test-net-after-close.js
+++ b/test/node/parallel/test-net-after-close.js
@@ -35,7 +35,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-var common = require('node/common');
+var common = require('../common');
 var assert = require('assert');
 var net = require('net');
 

--- a/test/node/parallel/test-net-bind-twice.js
+++ b/test/node/parallel/test-net-bind-twice.js
@@ -36,7 +36,7 @@
 
 'use strict';
 
-var common = require('node/common');
+var common = require('../common');
 var assert = require('assert');
 var net = require('net');
 

--- a/test/node/parallel/test-net-end-without-connect.js
+++ b/test/node/parallel/test-net-end-without-connect.js
@@ -35,7 +35,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('node/common');
+require('../common');
 var net = require('net');
 
 var sock = new net.Socket();

--- a/test/node/parallel/test-net-keepalive.js
+++ b/test/node/parallel/test-net-keepalive.js
@@ -36,7 +36,7 @@
 
 'use strict';
 
-var common = require('node/common');
+var common = require('../common');
 var assert = require('assert');
 var net = require('net');
 

--- a/test/node/parallel/test-timers-clear-null-does-not-throw-error.js
+++ b/test/node/parallel/test-timers-clear-null-does-not-throw-error.js
@@ -35,7 +35,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('node/common');
+require('../common');
 var assert = require('assert');
 
 // This test makes sure clearing timers with

--- a/test/run_pass/require1/test_index/index.js
+++ b/test/run_pass/require1/test_index/index.js
@@ -21,6 +21,6 @@ exports.add = function(a, b) {
   return a + b;
 };
 
-var x = require('lib/multi.js');
+var x = require('./lib/multi.js');
 exports.multi = x.multi;
 exports.add2 = x.add2;

--- a/test/run_pass/require1/test_index2/index_test.js
+++ b/test/run_pass/require1/test_index2/index_test.js
@@ -17,6 +17,6 @@ exports.add = function(a, b) {
   return a + b;
 };
 
-var x = require('lib/multi.js');
+var x = require('./lib/multi.js');
 exports.multi = x.multi;
 exports.add2 = x.add2;

--- a/test/run_pass/require1/test_pkg/main.js
+++ b/test/run_pass/require1/test_pkg/main.js
@@ -21,6 +21,6 @@ exports.add = function(a, b) {
   return a + b;
 };
 
-var x = require('lib/multi.js');
+var x = require('./lib/multi.js');
 exports.multi = x.multi;
 exports.add2 = x.add2;

--- a/test/run_pass/require2/node_modules/foobar/test.js
+++ b/test/run_pass/require2/node_modules/foobar/test.js
@@ -1,0 +1,4 @@
+'use strict';
+
+module.exports = 'test';
+

--- a/test/run_pass/test_module_cache.js
+++ b/test/run_pass/test_module_cache.js
@@ -14,8 +14,9 @@
  */
 
 var assert = require('assert');
+var path = require('path');
 
-var dir = process.cwd() + '/run_pass/require1/';
+var dir = path.join(__dirname, '../run_pass/require1/');
 var dirDoubleDot = dir + '../require1/';
 var dirDot = dir + './';
 

--- a/test/run_pass/test_module_json.js
+++ b/test/run_pass/test_module_json.js
@@ -14,7 +14,7 @@
  */
 
 var assert = require('assert');
-var json = require('./resources/test.json');
+var json = require('../resources/test.json');
 
 assert.equal(json.name, 'IoT.js');
 assert.equal(json.author, 'Samsung Electronics Co., Ltd.');

--- a/test/run_pass/test_module_require2.js
+++ b/test/run_pass/test_module_require2.js
@@ -3,3 +3,6 @@
 var assert = require('assert');
 var foobar = require('foobar');
 assert.equal(foobar, 'foobar');
+
+var test = require('foobar/test');
+assert.equal(test, 'test');

--- a/test/run_pass/test_module_require2.js
+++ b/test/run_pass/test_module_require2.js
@@ -1,6 +1,5 @@
 'use strict';
 
-console.log('', process.env)
 var assert = require('assert');
 var foobar = require('foobar');
 assert.equal(foobar, 'foobar');

--- a/test/run_pass/test_module_require2.js
+++ b/test/run_pass/test_module_require2.js
@@ -1,5 +1,6 @@
 'use strict';
 
+console.log('', process.env)
 var assert = require('assert');
 var foobar = require('foobar');
 assert.equal(foobar, 'foobar');

--- a/test/testsets.json
+++ b/test/testsets.json
@@ -58,7 +58,7 @@
     { "name": "test_module_require.js", "skip": ["nuttx"], "reason": "not implemented for nuttx" },
     { "name": "test_module_require2.js",
       "env": {
-        "NODE_PATH": "require2"
+        "NODE_PATH": "require2/node_modules"
       }
     },
     { "name": "test_net_1.js" },


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included(modified)
- [x] documentation is changed or added

Give the following optimizations:

- search rules:
  - If the `id` is a relative path, directly search by `__dirname`, no global module and `node_modules`.
  - If the `id` is a global path, directly try with file.
- tweak the order of global paths, level up the `NODE_PATH`.
- remove the retry with `index` after package main property is absence, because checked already before.

Also, this patch removes the way to load relative module without dots:

```js
require('test/foobar') // doesn't work
require('./test/foobar') // it's working
```