### PR TITLE
debug: add a new internal debug module for debugging based on env

### DIFF
--- a/src/js/debug.js
+++ b/src/js/debug.js
@@ -1,3 +1,5 @@
+/* eslint strict: [2, "never"] */
+
 var NODE_DEBUG = process.env.NODE_DEBUG;
 
 module.exports = function(tag) {

--- a/src/js/debug.js
+++ b/src/js/debug.js
@@ -1,0 +1,15 @@
+'use strict';
+
+var NODE_DEBUG = process.env.NODE_DEBUG;
+
+module.exports = function(tag) {
+  function debug(str) {
+    console.info(`:${tag}: ${str}`);
+  }
+  if (NODE_DEBUG === '*') {
+    return debug;
+  }
+  if (NODE_DEBUG === tag) {
+    return debug;
+  }
+};

--- a/src/js/debug.js
+++ b/src/js/debug.js
@@ -2,6 +2,10 @@
 
 var NODE_DEBUG = process.env.NODE_DEBUG;
 
+function skip() {
+  // Nothing
+}
+
 module.exports = function(tag) {
   function debug(str) {
     var prefix = '\033';
@@ -13,4 +17,5 @@ module.exports = function(tag) {
   if (NODE_DEBUG === tag) {
     return debug;
   }
+  return skip;
 };

--- a/src/js/debug.js
+++ b/src/js/debug.js
@@ -1,10 +1,9 @@
-'use strict';
-
 var NODE_DEBUG = process.env.NODE_DEBUG;
 
 module.exports = function(tag) {
   function debug(str) {
-    console.info(`:${tag}: ${str}`);
+    var prefix = '\033';
+    console.info(`${tag} ${prefix}[90m${str}${prefix}[0m`);
   }
   if (NODE_DEBUG === '*') {
     return debug;

--- a/src/js/module.js
+++ b/src/js/module.js
@@ -17,6 +17,7 @@
 var Native = require('native');
 var fs = Native.require('fs');
 var path = Native.require('path');
+var debug = Native.require('debug')('module');
 
 function iotjs_module_t(id, parent) {
   this.id = id;
@@ -67,6 +68,7 @@ function tryPath(modulePath, ext) {
 
 iotjs_module_t.tryPath = function(path) {
   try {
+    debug(`try load path ${path}`);
     var stats = fs.statSync(path);
     if (stats && !stats.isDirectory()) {
       return path;

--- a/src/modules.json
+++ b/src/modules.json
@@ -6,6 +6,7 @@
         "crypto",
         "child_process",
         "dbus",
+        "debug",
         "dns",
         "dgram",
         "http",
@@ -171,6 +172,9 @@
       "init": "InitDBus",
       "js_file": "js/dbus.js",
       "require": ["fs", "sax"]
+    },
+    "debug": {
+      "js_file": "js/debug.js"
     },
     "dgram": {
       "js_file": "js/dgram.js",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added

This is for logging informations for internal modules, for example:

```bash
$ NODE_DEBUG=module iotjs test.js
```