### PR TITLE
build: set DerivePointerAlignment to false

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -45,7 +45,7 @@ ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: false
-DerivePointerAlignment: true
+DerivePointerAlignment: false
 DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
 ForEachMacros:   [ ]

--- a/config/nuttx/stm32f4dis/app/iotjs_main.c
+++ b/config/nuttx/stm32f4dis/app/iotjs_main.c
@@ -60,13 +60,13 @@
  * Public Functions
  ****************************************************************************/
 
-extern int iotjs_entry(int argc, char *argv[]);
+extern int iotjs_entry(int argc, char* argv[]);
 extern int tuv_cleanup(void);
 
 #ifdef CONFIG_BUILD_KERNEL
-extern int main(int argc, FAR char *argv[])
+extern int main(int argc, FAR char* argv[])
 #else
-extern int iotjs_main(int argc, char *argv[])
+extern int iotjs_main(int argc, char* argv[])
 #endif
 {
   int ret = 0;

--- a/config/nuttx/stm32f4dis/app/jerry_port.c
+++ b/config/nuttx/stm32f4dis/app/jerry_port.c
@@ -32,7 +32,7 @@ void jerry_port_fatal(jerry_fatal_code_t code) {
  * Provide log message implementation for the engine.
  */
 void jerry_port_log(jerry_log_level_t level, /**< log level */
-                    const char *format,      /**< format string */
+                    const char* format,      /**< format string */
                     ...) {                   /**< parameters */
   /* Drain log messages since IoT.js has not support log levels yet. */
 } /* jerry_port_log */
@@ -42,7 +42,7 @@ void jerry_port_log(jerry_log_level_t level, /**< log level */
  *
  * @return true
  */
-bool jerry_port_get_time_zone(jerry_time_zone_t *tz_p) {
+bool jerry_port_get_time_zone(jerry_time_zone_t* tz_p) {
   /* We live in UTC. */
   tz_p->offset = 0;
   tz_p->daylight_saving_time = 0;

--- a/src/internal/node_api_internal.h
+++ b/src/internal/node_api_internal.h
@@ -36,7 +36,7 @@
 
 #define NAPI_TRY_NO_PENDING_EXCEPTION(env) \
   NAPI_WEAK_ASSERT(napi_pending_exception, \
-                   iotjs_napi_is_exception_pending((iotjs_napi_env_t *)env))
+                   iotjs_napi_is_exception_pending((iotjs_napi_env_t*)env))
 
 #define NAPI_INTERNAL_CALL(call) \
   do {                           \
@@ -52,19 +52,19 @@
   jerryx_create_handle(var);
 
 /** MARK: - node_api_module.c */
-int napi_module_init_pending(jerry_value_t *exports);
+int napi_module_init_pending(jerry_value_t* exports);
 /** MARK: - END node_api_module.c */
 
 /** MARK: - node_api_env.c */
 napi_env iotjs_get_current_napi_env();
-bool iotjs_napi_is_exception_pending(iotjs_napi_env_t *env);
+bool iotjs_napi_is_exception_pending(iotjs_napi_env_t* env);
 napi_status iotjs_napi_env_set_exception(napi_env env, napi_value error);
 napi_status iotjs_napi_env_set_fatal_exception(napi_env env, napi_value error);
 /** MARK: - END node_api_env.c */
 
 /** MARK: - node_api_lifetime.c */
 napi_status jerryx_status_to_napi_status(jerryx_handle_scope_status status);
-iotjs_object_info_t *iotjs_get_object_native_info(jerry_value_t jval,
+iotjs_object_info_t* iotjs_get_object_native_info(jerry_value_t jval,
                                                   size_t native_info_size);
 /** MARK: - END node_api_lifetime.c */
 

--- a/src/internal/node_api_internal_types.h
+++ b/src/internal/node_api_internal_types.h
@@ -20,7 +20,7 @@
 #include "jerryscript.h"
 #include "node_api.h"
 
-typedef napi_value (*jerry_addon_register_func)(void *env,
+typedef napi_value (*jerry_addon_register_func)(void* env,
                                                 jerry_value_t exports);
 
 typedef enum {
@@ -44,10 +44,10 @@ typedef struct {
 
 #define IOTJS_OBJECT_INFO_FIELDS \
   napi_env env;                  \
-  void *native_object;           \
+  void* native_object;           \
   napi_finalize finalize_cb;     \
-  void *finalize_hint;           \
-  iotjs_reference_t *ref;
+  void* finalize_hint;           \
+  iotjs_reference_t* ref;
 
 typedef struct {
   IOTJS_OBJECT_INFO_FIELDS;
@@ -57,15 +57,15 @@ typedef struct {
   IOTJS_OBJECT_INFO_FIELDS;
 
   napi_callback cb;
-  void *data;
+  void* data;
 } iotjs_function_info_t;
 
 typedef struct {
   size_t argc;
-  jerry_value_t *argv;
+  jerry_value_t* argv;
   jerry_value_t jval_this;
 
-  iotjs_function_info_t *function_info;
+  iotjs_function_info_t* function_info;
 } iotjs_callback_info_t;
 
 #endif // IOTJS_NODE_API_TYPES_H

--- a/src/iotjs_list.c
+++ b/src/iotjs_list.c
@@ -11,8 +11,8 @@
 /*
  * Allocate a new list_t. NULL on failure.
  */
-list_t *list_new() {
-  list_t *self;
+list_t* list_new() {
+  list_t* self;
   if (!(self = IOTJS_ALLOC(list_t)))
     return NULL;
   self->head = NULL;
@@ -26,8 +26,8 @@ list_t *list_new() {
 /*
  * Allocates a new list_node_t. NULL on failure.
  */
-list_node_t *list_node_new(void *val) {
-  list_node_t *self;
+list_node_t* list_node_new(void* val) {
+  list_node_t* self;
   if (!(self = IOTJS_ALLOC(list_node_t)))
     return NULL;
   self->prev = NULL;
@@ -39,10 +39,10 @@ list_node_t *list_node_new(void *val) {
 /*
  * Free the list.
  */
-void list_destroy(list_t *self) {
+void list_destroy(list_t* self) {
   unsigned int len = self->len;
-  list_node_t *next;
-  list_node_t *curr = self->head;
+  list_node_t* next;
+  list_node_t* curr = self->head;
 
   while (len--) {
     next = curr->next;
@@ -59,7 +59,7 @@ void list_destroy(list_t *self) {
  * Append the given node to the list
  * and return the node, NULL on failure.
  */
-list_node_t *list_rpush(list_t *self, list_node_t *node) {
+list_node_t* list_rpush(list_t* self, list_node_t* node) {
   if (!node)
     return NULL;
 
@@ -80,11 +80,11 @@ list_node_t *list_rpush(list_t *self, list_node_t *node) {
 /*
  * Return / detach the last node in the list, or NULL.
  */
-list_node_t *list_rpop(list_t *self) {
+list_node_t* list_rpop(list_t* self) {
   if (!self->len)
     return NULL;
 
-  list_node_t *node = self->tail;
+  list_node_t* node = self->tail;
 
   if (--self->len) {
     (self->tail = node->prev)->next = NULL;
@@ -99,11 +99,11 @@ list_node_t *list_rpop(list_t *self) {
 /*
  * Return / detach the first node in the list, or NULL.
  */
-list_node_t *list_lpop(list_t *self) {
+list_node_t* list_lpop(list_t* self) {
   if (!self->len)
     return NULL;
 
-  list_node_t *node = self->head;
+  list_node_t* node = self->head;
 
   if (--self->len) {
     (self->head = node->next)->prev = NULL;
@@ -119,7 +119,7 @@ list_node_t *list_lpop(list_t *self) {
  * Prepend the given node to the list
  * and return the node, NULL on failure.
  */
-list_node_t *list_lpush(list_t *self, list_node_t *node) {
+list_node_t* list_lpush(list_t* self, list_node_t* node) {
   if (!node)
     return NULL;
 
@@ -140,9 +140,9 @@ list_node_t *list_lpush(list_t *self, list_node_t *node) {
 /*
  * Return the node associated to val or NULL.
  */
-list_node_t *list_find(list_t *self, void *val) {
-  list_iterator_t *it = list_iterator_new(self, LIST_HEAD);
-  list_node_t *node;
+list_node_t* list_find(list_t* self, void* val) {
+  list_iterator_t* it = list_iterator_new(self, LIST_HEAD);
+  list_node_t* node;
 
   while ((node = list_iterator_next(it))) {
     if (self->match) {
@@ -165,7 +165,7 @@ list_node_t *list_find(list_t *self, void *val) {
 /*
  * Return the node at the given index or NULL.
  */
-list_node_t *list_at(list_t *self, int index) {
+list_node_t* list_at(list_t* self, int index) {
   list_direction_t direction = LIST_HEAD;
 
   if (index < 0) {
@@ -174,8 +174,8 @@ list_node_t *list_at(list_t *self, int index) {
   }
 
   if ((unsigned)index < self->len) {
-    list_iterator_t *it = list_iterator_new(self, direction);
-    list_node_t *node = list_iterator_next(it);
+    list_iterator_t* it = list_iterator_new(self, direction);
+    list_node_t* node = list_iterator_next(it);
     while (index--)
       node = list_iterator_next(it);
     list_iterator_destroy(it);
@@ -188,7 +188,7 @@ list_node_t *list_at(list_t *self, int index) {
 /*
  * Remove the given node from the list, freeing it and it's value.
  */
-void list_remove(list_t *self, list_node_t *node) {
+void list_remove(list_t* self, list_node_t* node) {
   node->prev ? (node->prev->next = node->next) : (self->head = node->next);
 
   node->next ? (node->next->prev = node->prev) : (self->tail = node->prev);
@@ -204,8 +204,8 @@ void list_remove(list_t *self, list_node_t *node) {
  * Allocate a new list_iterator_t. NULL on failure.
  * Accepts a direction, which may be LIST_HEAD or LIST_TAIL.
  */
-list_iterator_t *list_iterator_new(list_t *list, list_direction_t direction) {
-  list_node_t *node = direction == LIST_HEAD ? list->head : list->tail;
+list_iterator_t* list_iterator_new(list_t* list, list_direction_t direction) {
+  list_node_t* node = direction == LIST_HEAD ? list->head : list->tail;
   return list_iterator_new_from_node(node, direction);
 }
 
@@ -213,9 +213,9 @@ list_iterator_t *list_iterator_new(list_t *list, list_direction_t direction) {
  * Allocate a new list_iterator_t with the given start
  * node. NULL on failure.
  */
-list_iterator_t *list_iterator_new_from_node(list_node_t *node,
+list_iterator_t* list_iterator_new_from_node(list_node_t* node,
                                              list_direction_t direction) {
-  list_iterator_t *self;
+  list_iterator_t* self;
   if (!(self = IOTJS_ALLOC(list_iterator_t)))
     return NULL;
   self->next = node;
@@ -227,8 +227,8 @@ list_iterator_t *list_iterator_new_from_node(list_node_t *node,
  * Return the next list_node_t or NULL when no more
  * nodes remain in the list.
  */
-list_node_t *list_iterator_next(list_iterator_t *self) {
-  list_node_t *curr = self->next;
+list_node_t* list_iterator_next(list_iterator_t* self) {
+  list_node_t* curr = self->next;
   if (curr) {
     self->next = self->direction == LIST_HEAD ? curr->next : curr->prev;
   }
@@ -238,7 +238,7 @@ list_node_t *list_iterator_next(list_iterator_t *self) {
 /*
  * Free the list iterator.
  */
-void list_iterator_destroy(list_iterator_t *self) {
+void list_iterator_destroy(list_iterator_t* self) {
   IOTJS_RELEASE(self);
   self = NULL;
 }

--- a/src/iotjs_list.h
+++ b/src/iotjs_list.h
@@ -18,49 +18,49 @@ typedef enum { LIST_HEAD, LIST_TAIL } list_direction_t;
  * list_t node struct.
  */
 typedef struct list_node {
-  struct list_node *prev;
-  struct list_node *next;
-  void *val;
+  struct list_node* prev;
+  struct list_node* next;
+  void* val;
 } list_node_t;
 
 /*
  * list_t struct.
  */
 typedef struct {
-  list_node_t *head;
-  list_node_t *tail;
+  list_node_t* head;
+  list_node_t* tail;
   unsigned int len;
-  void (*free)(void *val);
-  int (*match)(void *a, void *b);
+  void (*free)(void* val);
+  int (*match)(void* a, void* b);
 } list_t;
 
 /*
  * list_t iterator struct.
  */
 typedef struct {
-  list_node_t *next;
+  list_node_t* next;
   list_direction_t direction;
 } list_iterator_t;
 
 // Node prototypes.
-list_node_t *list_node_new(void *val);
+list_node_t* list_node_new(void* val);
 
 // list_t prototypes.
-list_t *list_new();
-list_node_t *list_rpush(list_t *self, list_node_t *node);
-list_node_t *list_lpush(list_t *self, list_node_t *node);
-list_node_t *list_find(list_t *self, void *val);
-list_node_t *list_at(list_t *self, int index);
-list_node_t *list_rpop(list_t *self);
-list_node_t *list_lpop(list_t *self);
-void list_remove(list_t *self, list_node_t *node);
-void list_destroy(list_t *self);
+list_t* list_new();
+list_node_t* list_rpush(list_t* self, list_node_t* node);
+list_node_t* list_lpush(list_t* self, list_node_t* node);
+list_node_t* list_find(list_t* self, void* val);
+list_node_t* list_at(list_t* self, int index);
+list_node_t* list_rpop(list_t* self);
+list_node_t* list_lpop(list_t* self);
+void list_remove(list_t* self, list_node_t* node);
+void list_destroy(list_t* self);
 
 // list_t iterator prototypes.
-list_iterator_t *list_iterator_new(list_t *list, list_direction_t direction);
-list_iterator_t *list_iterator_new_from_node(list_node_t *node,
+list_iterator_t* list_iterator_new(list_t* list, list_direction_t direction);
+list_iterator_t* list_iterator_new_from_node(list_node_t* node,
                                              list_direction_t direction);
-list_node_t *list_iterator_next(list_iterator_t *self);
-void list_iterator_destroy(list_iterator_t *self);
+list_node_t* list_iterator_next(list_iterator_t* self);
+void list_iterator_destroy(list_iterator_t* self);
 
 #endif /* IOTJS_LIST_H */

--- a/src/modules/iotjs_module_crypto.c
+++ b/src/modules/iotjs_module_crypto.c
@@ -29,7 +29,7 @@ jerry_value_t InitCrypto() {
   mbedtls_entropy_init(&entropy);
   mbedtls_ctr_drbg_init(&drgb_ctx);
   mbedtls_ctr_drbg_seed(&drgb_ctx, mbedtls_entropy_func, &entropy,
-                        (const unsigned char *)CRYPTO_DRGB_PERSONAL_KEY,
+                        (const unsigned char*)CRYPTO_DRGB_PERSONAL_KEY,
                         strlen(CRYPTO_DRGB_PERSONAL_KEY));
 
   jerry_value_t crypto = jerry_create_object();

--- a/src/modules/iotjs_module_tls_bio.c
+++ b/src/modules/iotjs_module_tls_bio.c
@@ -1,7 +1,7 @@
 #include "iotjs_module_tls_bio.h"
 
 /* Return the number of pending bytes in read and write buffers */
-size_t iotjs_bio_ctrl_pending(BIO *bio) {
+size_t iotjs_bio_ctrl_pending(BIO* bio) {
   if (bio == NULL) {
     return 0;
   }
@@ -12,7 +12,7 @@ size_t iotjs_bio_ctrl_pending(BIO *bio) {
 
   /* type BIO_BIO then check paired buffer */
   if (bio->type == BIO_BIO && bio->pair != NULL) {
-    BIO *pair = bio->pair;
+    BIO* pair = bio->pair;
 
     if (pair->wrIdx > 0 && pair->wrIdx <= pair->rdIdx) {
       /* in wrap around state where begining of buffer is being
@@ -26,7 +26,7 @@ size_t iotjs_bio_ctrl_pending(BIO *bio) {
   return 0;
 }
 
-int iotjs_bio_set_write_buf_size(BIO *bio, long size) {
+int iotjs_bio_set_write_buf_size(BIO* bio, long size) {
   if (bio == NULL || bio->type != BIO_BIO || size < 0) {
     return SSL_FAILURE;
   }
@@ -45,7 +45,7 @@ int iotjs_bio_set_write_buf_size(BIO *bio, long size) {
     free(bio->mem);
   }
 
-  bio->mem = (BYTE *)malloc((size_t)bio->wrSz);
+  bio->mem = (BYTE*)malloc((size_t)bio->wrSz);
   if (bio->mem == NULL) {
     return SSL_FAILURE;
   }
@@ -60,7 +60,7 @@ int iotjs_bio_set_write_buf_size(BIO *bio, long size) {
  * versa. Creating something similar to a two way pipe.
  * Reading and writing between the two BIOs is not thread safe, they are
  * expected to be used by the same thread. */
-int iotjs_bio_make_bio_pair(BIO *b1, BIO *b2) {
+int iotjs_bio_make_bio_pair(BIO* b1, BIO* b2) {
   if (b1 == NULL || b2 == NULL) {
     return SSL_FAILURE;
   }
@@ -90,17 +90,17 @@ int iotjs_bio_make_bio_pair(BIO *b1, BIO *b2) {
 
 
 /* Does not advance read index pointer */
-int iotjs_bio_nread0(BIO *bio, char **buf) {
+int iotjs_bio_nread0(BIO* bio, char** buf) {
   if (bio == NULL || buf == NULL) {
     return 0;
   }
 
   /* if paired read from pair */
   if (bio->pair != NULL) {
-    BIO *pair = bio->pair;
+    BIO* pair = bio->pair;
 
     /* case where have wrapped around write buffer */
-    *buf = (char *)pair->mem + pair->rdIdx;
+    *buf = (char*)pair->mem + pair->rdIdx;
     if (pair->wrIdx > 0 && pair->rdIdx >= pair->wrIdx) {
       return pair->wrSz - pair->rdIdx;
     } else {
@@ -112,7 +112,7 @@ int iotjs_bio_nread0(BIO *bio, char **buf) {
 
 
 /* similar to SSL_BIO_nread0 but advances the read index */
-int iotjs_bio_nread(BIO *bio, char **buf, size_t num) {
+int iotjs_bio_nread(BIO* bio, char** buf, size_t num) {
   int sz = SSL_BIO_UNSET;
 
   if (bio == NULL || buf == NULL) {
@@ -122,7 +122,7 @@ int iotjs_bio_nread(BIO *bio, char **buf, size_t num) {
   if (bio->pair != NULL) {
     /* special case if asking to read 0 bytes */
     if (num == 0) {
-      *buf = (char *)bio->pair->mem + bio->pair->rdIdx;
+      *buf = (char*)bio->pair->mem + bio->pair->rdIdx;
       return 0;
     }
 
@@ -156,7 +156,7 @@ int iotjs_bio_nread(BIO *bio, char **buf, size_t num) {
 }
 
 
-int iotjs_bio_nwrite(BIO *bio, char **buf, int num) {
+int iotjs_bio_nwrite(BIO* bio, char** buf, int num) {
   int sz = SSL_BIO_UNSET;
 
   if (bio == NULL || buf == NULL) {
@@ -165,7 +165,7 @@ int iotjs_bio_nwrite(BIO *bio, char **buf, int num) {
 
   if (bio->pair != NULL) {
     if (num == 0) {
-      *buf = (char *)bio->mem + bio->wrIdx;
+      *buf = (char*)bio->mem + bio->wrIdx;
       return 0;
     }
 
@@ -201,7 +201,7 @@ int iotjs_bio_nwrite(BIO *bio, char **buf, int num) {
     if (num < sz) {
       sz = num;
     }
-    *buf = (char *)bio->mem + bio->wrIdx;
+    *buf = (char*)bio->mem + bio->wrIdx;
     bio->wrIdx += sz;
 
     /* if at the end of the buffer and space for wrap around then set
@@ -216,7 +216,7 @@ int iotjs_bio_nwrite(BIO *bio, char **buf, int num) {
 
 
 /* Reset BIO to initial state */
-int iotjs_bio_reset(BIO *bio) {
+int iotjs_bio_reset(BIO* bio) {
   if (bio == NULL) {
     /* -1 is consistent failure even for FILE type */
     return SSL_BIO_ERROR;
@@ -235,23 +235,23 @@ int iotjs_bio_reset(BIO *bio) {
 }
 
 
-int iotjs_bio_read(BIO *bio, const char *buf, size_t size) {
+int iotjs_bio_read(BIO* bio, const char* buf, size_t size) {
   int sz;
-  char *pt;
+  char* pt;
   sz = iotjs_bio_nread(bio, &pt, size);
 
   if (sz > 0) {
-    memset((void *)buf, 0, (size_t)sz);
-    memcpy((void *)buf, pt, (size_t)sz);
+    memset((void*)buf, 0, (size_t)sz);
+    memcpy((void*)buf, pt, (size_t)sz);
   }
 
   return sz;
 }
 
-int iotjs_bio_write(BIO *bio, const char *buf, size_t size) {
+int iotjs_bio_write(BIO* bio, const char* buf, size_t size) {
   /* internal function where arguments have already been sanity checked */
   int sz;
-  char *data;
+  char* data;
 
   sz = iotjs_bio_nwrite(bio, &data, (int)size);
 
@@ -272,8 +272,8 @@ int iotjs_bio_write(BIO *bio, const char *buf, size_t size) {
  * @param type
  * @return
  */
-BIO *iotjs_ssl_bio_new(int type) {
-  BIO *bio = (BIO *)malloc(sizeof(BIO));
+BIO* iotjs_ssl_bio_new(int type) {
+  BIO* bio = (BIO*)malloc(sizeof(BIO));
   if (bio) {
     bzero(bio, sizeof(BIO));
     bio->type = type;
@@ -284,7 +284,7 @@ BIO *iotjs_ssl_bio_new(int type) {
   return bio;
 }
 
-int iotjs_bio_free(BIO *bio) {
+int iotjs_bio_free(BIO* bio) {
   /* unchain?, doesn't matter in goahead since from free all */
   if (bio) {
     /* remove from pair by setting the paired bios pair to NULL */
@@ -298,30 +298,30 @@ int iotjs_bio_free(BIO *bio) {
   return 0;
 }
 
-int iotjs_bio_free_all(BIO *bio) {
+int iotjs_bio_free_all(BIO* bio) {
   while (bio) {
-    BIO *next = bio->next;
+    BIO* next = bio->next;
     iotjs_bio_free(bio);
     bio = next;
   }
   return 0;
 }
 
-int iotjs_bio_net_send(void *ctx, const unsigned char *buf, size_t len) {
-  BIO *bio = (BIO *)ctx;
+int iotjs_bio_net_send(void* ctx, const unsigned char* buf, size_t len) {
+  BIO* bio = (BIO*)ctx;
 
   int sz;
-  sz = iotjs_bio_write(bio, (const char *)buf, len);
+  sz = iotjs_bio_write(bio, (const char*)buf, len);
   if (sz <= 0) {
     return MBEDTLS_ERR_SSL_WANT_WRITE;
   }
   return sz;
 }
 
-int iotjs_bio_net_recv(void *ctx, unsigned char *buf, size_t len) {
-  BIO *bio = (BIO *)ctx;
+int iotjs_bio_net_recv(void* ctx, unsigned char* buf, size_t len) {
+  BIO* bio = (BIO*)ctx;
   int sz;
-  sz = iotjs_bio_read(bio, (const char *)buf, len);
+  sz = iotjs_bio_read(bio, (const char*)buf, len);
 
   if (sz <= 0) {
     return MBEDTLS_ERR_SSL_WANT_READ;

--- a/src/modules/iotjs_module_tls_bio.h
+++ b/src/modules/iotjs_module_tls_bio.h
@@ -69,10 +69,10 @@ struct _BIO;
 typedef struct _BIO BIO;
 
 struct _BIO {
-  BIO *prev;  /* previous in chain */
-  BIO *next;  /* next in chain */
-  BIO *pair;  /* BIO paired with */
-  BYTE *mem;  /* memory buffer */
+  BIO* prev;  /* previous in chain */
+  BIO* next;  /* next in chain */
+  BIO* pair;  /* BIO paired with */
+  BYTE* mem;  /* memory buffer */
   int wrSz;   /* write buffer size (mem) */
   int wrIdx;  /* current index for write buffer */
   int rdIdx;  /* current read index */
@@ -96,17 +96,17 @@ enum BIO_TYPE {
   BIO_FILE = 6
 };
 
-BIO *iotjs_ssl_bio_new(int type);
-int iotjs_bio_make_bio_pair(BIO *b1, BIO *b2);
+BIO* iotjs_ssl_bio_new(int type);
+int iotjs_bio_make_bio_pair(BIO* b1, BIO* b2);
 
-size_t iotjs_bio_ctrl_pending(BIO *bio);
-int iotjs_bio_read(BIO *bio, const char *buf, size_t size);
-int iotjs_bio_write(BIO *bio, const char *buf, size_t size);
+size_t iotjs_bio_ctrl_pending(BIO* bio);
+int iotjs_bio_read(BIO* bio, const char* buf, size_t size);
+int iotjs_bio_write(BIO* bio, const char* buf, size_t size);
 
-int iotjs_bio_reset(BIO *bio);
-int iotjs_bio_net_recv(void *ctx, unsigned char *buf, size_t len);
-int iotjs_bio_net_send(void *ctx, const unsigned char *buf, size_t len);
-int iotjs_bio_free_all(BIO *bio);
-int iotjs_bio_free(BIO *bio);
+int iotjs_bio_reset(BIO* bio);
+int iotjs_bio_net_recv(void* ctx, unsigned char* buf, size_t len);
+int iotjs_bio_net_send(void* ctx, const unsigned char* buf, size_t len);
+int iotjs_bio_free_all(BIO* bio);
+int iotjs_bio_free(BIO* bio);
 
 #endif // IOTJS_MODULE_TLS_BIO_H

--- a/src/napi/node_api_env.c
+++ b/src/napi/node_api_env.c
@@ -25,7 +25,7 @@ inline napi_env iotjs_get_current_napi_env() {
   return (napi_env)&current_env;
 }
 
-inline bool iotjs_napi_is_exception_pending(iotjs_napi_env_t *env) {
+inline bool iotjs_napi_is_exception_pending(iotjs_napi_env_t* env) {
   return !(env->pending_exception == NULL &&
            env->pending_fatal_exception == NULL);
 }
@@ -33,7 +33,7 @@ inline bool iotjs_napi_is_exception_pending(iotjs_napi_env_t *env) {
 napi_status iotjs_napi_env_set_exception(napi_env env, napi_value error) {
   if (env != iotjs_get_current_napi_env())
     return napi_invalid_arg;
-  iotjs_napi_env_t *cur_env = (iotjs_napi_env_t *)env;
+  iotjs_napi_env_t* cur_env = (iotjs_napi_env_t*)env;
 
   cur_env->pending_exception = error;
   return napi_ok;
@@ -42,7 +42,7 @@ napi_status iotjs_napi_env_set_exception(napi_env env, napi_value error) {
 napi_status iotjs_napi_env_set_fatal_exception(napi_env env, napi_value error) {
   if (env != iotjs_get_current_napi_env())
     return napi_invalid_arg;
-  iotjs_napi_env_t *cur_env = (iotjs_napi_env_t *)env;
+  iotjs_napi_env_t* cur_env = (iotjs_napi_env_t*)env;
 
   cur_env->pending_exception = error;
   return napi_ok;
@@ -52,25 +52,25 @@ napi_status iotjs_napi_env_set_fatal_exception(napi_env env, napi_value error) {
 napi_status napi_throw(napi_env env, napi_value error) {
   if (env != iotjs_get_current_napi_env())
     return napi_invalid_arg;
-  iotjs_napi_env_t *curr_env = (iotjs_napi_env_t *)env;
+  iotjs_napi_env_t* curr_env = (iotjs_napi_env_t*)env;
   if (iotjs_napi_is_exception_pending(curr_env))
     return napi_pending_exception;
   curr_env->pending_exception = error;
   return napi_ok;
 }
 
-#define DEF_NAPI_THROWS(type, jerry_error_type)                    \
-  napi_status napi_throw_##type(napi_env env, const char *code,    \
-                                const char *msg) {                 \
-    if (env != iotjs_get_current_napi_env())                       \
-      return napi_invalid_arg;                                     \
-    if (iotjs_napi_is_exception_pending((iotjs_napi_env_t *)env))  \
-      return napi_pending_exception;                               \
-                                                                   \
-    jerry_value_t jval_error =                                     \
-        jerry_create_error(jerry_error_type, (jerry_char_t *)msg); \
-    iotjs_jval_set_property_string_raw(jval_error, "code", code);  \
-    return napi_throw(env, AS_NAPI_VALUE(jval_error));             \
+#define DEF_NAPI_THROWS(type, jerry_error_type)                   \
+  napi_status napi_throw_##type(napi_env env, const char* code,   \
+                                const char* msg) {                \
+    if (env != iotjs_get_current_napi_env())                      \
+      return napi_invalid_arg;                                    \
+    if (iotjs_napi_is_exception_pending((iotjs_napi_env_t*)env))  \
+      return napi_pending_exception;                              \
+                                                                  \
+    jerry_value_t jval_error =                                    \
+        jerry_create_error(jerry_error_type, (jerry_char_t*)msg); \
+    iotjs_jval_set_property_string_raw(jval_error, "code", code); \
+    return napi_throw(env, AS_NAPI_VALUE(jval_error));            \
   }
 
 DEF_NAPI_THROWS(error, JERRY_ERROR_COMMON);
@@ -81,7 +81,7 @@ DEF_NAPI_THROWS(range_error, JERRY_ERROR_RANGE);
 napi_status napi_fatal_exception(napi_env env, napi_value err) {
   if (env != iotjs_get_current_napi_env())
     return napi_invalid_arg;
-  iotjs_napi_env_t *curr_env = (iotjs_napi_env_t *)env;
+  iotjs_napi_env_t* curr_env = (iotjs_napi_env_t*)env;
   if (iotjs_napi_is_exception_pending(curr_env))
     return napi_pending_exception;
   curr_env->pending_fatal_exception = err;
@@ -90,18 +90,18 @@ napi_status napi_fatal_exception(napi_env env, napi_value err) {
 
 
 // Methods to support catching exceptions
-napi_status napi_is_exception_pending(napi_env env, bool *result) {
+napi_status napi_is_exception_pending(napi_env env, bool* result) {
   if (env != iotjs_get_current_napi_env())
     return napi_invalid_arg;
-  *result = iotjs_napi_is_exception_pending((iotjs_napi_env_t *)env);
+  *result = iotjs_napi_is_exception_pending((iotjs_napi_env_t*)env);
   return napi_ok;
 }
 
 napi_status napi_get_and_clear_last_exception(napi_env env,
-                                              napi_value *result) {
+                                              napi_value* result) {
   if (env != iotjs_get_current_napi_env())
     return napi_invalid_arg;
-  iotjs_napi_env_t *curr_env = (iotjs_napi_env_t *)env;
+  iotjs_napi_env_t* curr_env = (iotjs_napi_env_t*)env;
 
   if (curr_env->pending_exception != NULL) {
     *result = curr_env->pending_exception;
@@ -115,11 +115,11 @@ napi_status napi_get_and_clear_last_exception(napi_env env,
 
 
 napi_status napi_get_last_error_info(napi_env env,
-                                     const napi_extended_error_info **result) {
+                                     const napi_extended_error_info** result) {
   if (env != iotjs_get_current_napi_env())
     return napi_invalid_arg;
-  iotjs_napi_env_t *curr_env = (iotjs_napi_env_t *)env;
-  napi_extended_error_info *error_info = &curr_env->extended_error_info;
+  iotjs_napi_env_t* curr_env = (iotjs_napi_env_t*)env;
+  napi_extended_error_info* error_info = &curr_env->extended_error_info;
 
   *result = error_info;
   return napi_ok;

--- a/src/napi/node_api_function.c
+++ b/src/napi/node_api_function.c
@@ -25,11 +25,11 @@ static const jerry_object_native_info_t native_obj_type_info = { .free_cb =
 static jerry_value_t iotjs_napi_function_handler(
     const jerry_value_t function_obj, const jerry_value_t this_val,
     const jerry_value_t args_p[], const jerry_length_t args_cnt) {
-  iotjs_function_info_t *function_info;
-  jerry_get_object_native_pointer(function_obj, (void *)&function_info, NULL);
-  iotjs_callback_info_t *callback_info = IOTJS_ALLOC(iotjs_callback_info_t);
+  iotjs_function_info_t* function_info;
+  jerry_get_object_native_pointer(function_obj, (void*)&function_info, NULL);
+  iotjs_callback_info_t* callback_info = IOTJS_ALLOC(iotjs_callback_info_t);
   callback_info->argc = args_cnt;
-  callback_info->argv = (jerry_value_t *)args_p;
+  callback_info->argv = (jerry_value_t*)args_p;
   callback_info->jval_this = this_val;
   callback_info->function_info = function_info;
 
@@ -43,7 +43,7 @@ static jerry_value_t iotjs_napi_function_handler(
       function_info->cb(env, (napi_callback_info)callback_info);
   free(callback_info);
 
-  iotjs_napi_env_t *iotjs_napi_env = (iotjs_napi_env_t *)env;
+  iotjs_napi_env_t* iotjs_napi_env = (iotjs_napi_env_t*)env;
   if (iotjs_napi_is_exception_pending(iotjs_napi_env)) {
     if (iotjs_napi_env->pending_exception != NULL) {
       jval_ret = AS_JERRY_VALUE(iotjs_napi_env->pending_exception);
@@ -70,14 +70,14 @@ cleanup:
   return jval_ret;
 }
 
-napi_status napi_create_function(napi_env env, const char *utf8name,
-                                 size_t length, napi_callback cb, void *data,
-                                 napi_value *result) {
+napi_status napi_create_function(napi_env env, const char* utf8name,
+                                 size_t length, napi_callback cb, void* data,
+                                 napi_value* result) {
   jerry_value_t jval_func =
       jerry_create_external_function(iotjs_napi_function_handler);
   jerryx_create_handle(jval_func);
 
-  iotjs_function_info_t *function_info = (iotjs_function_info_t *)
+  iotjs_function_info_t* function_info = (iotjs_function_info_t*)
       iotjs_get_object_native_info(jval_func, sizeof(iotjs_function_info_t));
   function_info->env = env;
   function_info->cb = cb;
@@ -90,8 +90,8 @@ napi_status napi_create_function(napi_env env, const char *utf8name,
 }
 
 napi_status napi_call_function(napi_env env, napi_value recv, napi_value func,
-                               size_t argc, const napi_value *argv,
-                               napi_value *result) {
+                               size_t argc, const napi_value* argv,
+                               napi_value* result) {
   NAPI_TRY_NO_PENDING_EXCEPTION(env);
 
   jerry_value_t jval_func = AS_JERRY_VALUE(func);
@@ -100,7 +100,7 @@ napi_status napi_call_function(napi_env env, napi_value recv, napi_value func,
   NAPI_TRY_TYPE(function, jval_func);
 
   jerry_value_t jval_ret =
-      jerry_call_function(jval_func, jval_this, (jerry_value_t *)argv, argc);
+      jerry_call_function(jval_func, jval_this, (jerry_value_t*)argv, argc);
   jerryx_create_handle(jval_ret);
   if (jerry_value_has_error_flag(jval_ret)) {
     NAPI_INTERNAL_CALL(napi_throw(env, AS_NAPI_VALUE(jval_ret)));
@@ -112,9 +112,9 @@ napi_status napi_call_function(napi_env env, napi_value recv, napi_value func,
 }
 
 napi_status napi_get_cb_info(napi_env env, napi_callback_info cbinfo,
-                             size_t *argc, napi_value *argv,
-                             napi_value *thisArg, void **data) {
-  iotjs_callback_info_t *callback_info = (iotjs_callback_info_t *)cbinfo;
+                             size_t* argc, napi_value* argv,
+                             napi_value* thisArg, void** data) {
+  iotjs_callback_info_t* callback_info = (iotjs_callback_info_t*)cbinfo;
 
   for (size_t i = 0; i < *argc && i < callback_info->argc; ++i) {
     argv[i] = AS_NAPI_VALUE(callback_info->argv[i]);
@@ -128,7 +128,7 @@ napi_status napi_get_cb_info(napi_env env, napi_callback_info cbinfo,
 }
 
 napi_status napi_new_instance(napi_env env, napi_value constructor, size_t argc,
-                              const napi_value *argv, napi_value *result) {
+                              const napi_value* argv, napi_value* result) {
   NAPI_TRY_NO_PENDING_EXCEPTION(env);
 
   jerry_value_t jval_cons = AS_JERRY_VALUE(constructor);
@@ -136,7 +136,7 @@ napi_status napi_new_instance(napi_env env, napi_value constructor, size_t argc,
   NAPI_TRY_TYPE(function, jval_cons);
 
   jerry_value_t jval_ret =
-      jerry_construct_object(jval_cons, (jerry_value_t *)argv, argc);
+      jerry_construct_object(jval_cons, (jerry_value_t*)argv, argc);
   jerryx_create_handle(jval_ret);
   if (jerry_value_has_error_flag(jval_ret)) {
     NAPI_INTERNAL_CALL(napi_throw(env, AS_NAPI_VALUE(jval_ret)));

--- a/src/napi/node_api_lifetime.c
+++ b/src/napi/node_api_lifetime.c
@@ -16,8 +16,8 @@
 #include "jerryscript-ext/handle-scope.h"
 #include "internal/node_api_internal.h"
 
-static void native_info_free(void *native_info) {
-  iotjs_object_info_t *info = (iotjs_object_info_t *)native_info;
+static void native_info_free(void* native_info) {
+  iotjs_object_info_t* info = (iotjs_object_info_t*)native_info;
   if (info->ref != NULL) {
     info->ref->jval = AS_JERRY_VALUE(NULL);
   }
@@ -45,13 +45,13 @@ inline napi_status jerryx_status_to_napi_status(
   }
 }
 
-iotjs_object_info_t *iotjs_get_object_native_info(jerry_value_t jval,
+iotjs_object_info_t* iotjs_get_object_native_info(jerry_value_t jval,
                                                   size_t native_info_size) {
-  iotjs_object_info_t *info;
+  iotjs_object_info_t* info;
   bool has_native_ptr =
-      jerry_get_object_native_pointer(jval, (void **)&info, NULL);
+      jerry_get_object_native_pointer(jval, (void**)&info, NULL);
   if (!has_native_ptr) {
-    info = (iotjs_object_info_t *)iotjs_buffer_allocate(
+    info = (iotjs_object_info_t*)iotjs_buffer_allocate(
         native_info_size < sizeof(iotjs_object_info_t)
             ? sizeof(iotjs_object_info_t)
             : native_info_size);
@@ -61,18 +61,18 @@ iotjs_object_info_t *iotjs_get_object_native_info(jerry_value_t jval,
   return info;
 }
 
-napi_status napi_open_handle_scope(napi_env env, napi_handle_scope *result) {
+napi_status napi_open_handle_scope(napi_env env, napi_handle_scope* result) {
   jerryx_handle_scope_status status;
-  status = jerryx_open_handle_scope((jerryx_handle_scope *)result);
+  status = jerryx_open_handle_scope((jerryx_handle_scope*)result);
 
   return jerryx_status_to_napi_status(status);
 }
 
 napi_status napi_open_escapable_handle_scope(
-    napi_env env, napi_escapable_handle_scope *result) {
+    napi_env env, napi_escapable_handle_scope* result) {
   jerryx_handle_scope_status status;
   status = jerryx_open_escapable_handle_scope(
-      (jerryx_escapable_handle_scope *)result);
+      (jerryx_escapable_handle_scope*)result);
 
   return jerryx_status_to_napi_status(status);
 }
@@ -94,28 +94,28 @@ napi_status napi_close_escapable_handle_scope(
 }
 
 napi_status napi_escape_handle(napi_env env, napi_escapable_handle_scope scope,
-                               napi_value escapee, napi_value *result) {
+                               napi_value escapee, napi_value* result) {
   jerryx_handle_scope_status status;
   status =
       jerryx_escape_handle((jerryx_escapable_handle_scope)scope,
-                           AS_JERRY_VALUE(escapee), (jerry_value_t *)result);
+                           AS_JERRY_VALUE(escapee), (jerry_value_t*)result);
 
   return jerryx_status_to_napi_status(status);
 }
 
 napi_status napi_create_reference(napi_env env, napi_value value,
-                                  uint32_t initial_refcount, napi_ref *result) {
+                                  uint32_t initial_refcount, napi_ref* result) {
   jerry_value_t jval = AS_JERRY_VALUE(value);
-  iotjs_object_info_t *info;
+  iotjs_object_info_t* info;
   bool has_native_ptr =
-      jerry_get_object_native_pointer(jval, (void **)&info, NULL);
+      jerry_get_object_native_pointer(jval, (void**)&info, NULL);
   if (!has_native_ptr) {
     info = IOTJS_ALLOC(iotjs_object_info_t);
   } else {
     NAPI_WEAK_ASSERT(napi_invalid_arg, (info->ref != NULL));
   }
 
-  iotjs_reference_t *ref = IOTJS_ALLOC(iotjs_reference_t);
+  iotjs_reference_t* ref = IOTJS_ALLOC(iotjs_reference_t);
   ref->refcount = initial_refcount;
   ref->jval = AS_JERRY_VALUE(value);
   info->ref = ref;
@@ -125,12 +125,12 @@ napi_status napi_create_reference(napi_env env, napi_value value,
 }
 
 napi_status napi_delete_reference(napi_env env, napi_ref ref) {
-  iotjs_reference_t *iot_ref = (iotjs_reference_t *)ref;
+  iotjs_reference_t* iot_ref = (iotjs_reference_t*)ref;
   if (iot_ref->jval != AS_JERRY_VALUE(NULL)) {
     jerry_value_t jval = iot_ref->jval;
-    iotjs_object_info_t *info;
+    iotjs_object_info_t* info;
     bool has_native_ptr =
-        jerry_get_object_native_pointer(jval, (void **)&info, NULL);
+        jerry_get_object_native_pointer(jval, (void**)&info, NULL);
     NAPI_WEAK_ASSERT(napi_invalid_arg, has_native_ptr);
     NAPI_WEAK_ASSERT(napi_invalid_arg, (info->ref == iot_ref));
     info->ref = NULL;
@@ -142,8 +142,8 @@ napi_status napi_delete_reference(napi_env env, napi_ref ref) {
   return napi_ok;
 }
 
-napi_status napi_reference_ref(napi_env env, napi_ref ref, uint32_t *result) {
-  iotjs_reference_t *iot_ref = (iotjs_reference_t *)ref;
+napi_status napi_reference_ref(napi_env env, napi_ref ref, uint32_t* result) {
+  iotjs_reference_t* iot_ref = (iotjs_reference_t*)ref;
   NAPI_WEAK_ASSERT(napi_invalid_arg, (iot_ref->jval != AS_JERRY_VALUE(NULL)));
 
   jerry_acquire_value(iot_ref->jval);
@@ -153,8 +153,8 @@ napi_status napi_reference_ref(napi_env env, napi_ref ref, uint32_t *result) {
   return napi_ok;
 }
 
-napi_status napi_reference_unref(napi_env env, napi_ref ref, uint32_t *result) {
-  iotjs_reference_t *iot_ref = (iotjs_reference_t *)ref;
+napi_status napi_reference_unref(napi_env env, napi_ref ref, uint32_t* result) {
+  iotjs_reference_t* iot_ref = (iotjs_reference_t*)ref;
   NAPI_WEAK_ASSERT(napi_invalid_arg, (iot_ref->refcount > 0));
 
   jerry_release_value(iot_ref->jval);
@@ -165,8 +165,8 @@ napi_status napi_reference_unref(napi_env env, napi_ref ref, uint32_t *result) {
 }
 
 napi_status napi_get_reference_value(napi_env env, napi_ref ref,
-                                     napi_value *result) {
-  iotjs_reference_t *iot_ref = (iotjs_reference_t *)ref;
+                                     napi_value* result) {
+  iotjs_reference_t* iot_ref = (iotjs_reference_t*)ref;
   *result = AS_NAPI_VALUE(iot_ref->jval);
   return napi_ok;
 }

--- a/src/napi/node_api_module.c
+++ b/src/napi/node_api_module.c
@@ -18,13 +18,13 @@
 #include "internal/node_api_internal.h"
 #include "node_api.h"
 
-static napi_module *mod_pending;
+static napi_module* mod_pending;
 
-void napi_module_register(napi_module *mod) {
+void napi_module_register(napi_module* mod) {
   mod_pending = mod;
 }
 
-int napi_module_init_pending(jerry_value_t *exports) {
+int napi_module_init_pending(jerry_value_t* exports) {
   if (mod_pending == NULL) {
     return napi_module_no_pending;
   }

--- a/src/platform/tizenrt/iotjs_main_tizenrt.c
+++ b/src/platform/tizenrt/iotjs_main_tizenrt.c
@@ -42,7 +42,7 @@ void jerry_port_fatal(jerry_fatal_code_t code) {
  * Provide log message implementation for the engine.
  */
 void jerry_port_log(jerry_log_level_t level, /**< log level */
-                    const char *format,      /**< format string */
+                    const char* format,      /**< format string */
                     ...) {                   /**< parameters */
   /* Drain log messages since IoT.js has not support log levels yet. */
 } /* jerry_port_log */
@@ -52,7 +52,7 @@ void jerry_port_log(jerry_log_level_t level, /**< log level */
  *
  * @return true
  */
-bool jerry_port_get_time_zone(jerry_time_zone_t *tz_p) {
+bool jerry_port_get_time_zone(jerry_time_zone_t* tz_p) {
   /* We live in UTC. */
   tz_p->offset = 0;
   tz_p->daylight_saving_time = 0;
@@ -101,18 +101,18 @@ void longjmp(jmp_buf buf, int value) {
   __builtin_longjmp(buf, 1);
 } /* longjmp */
 
-int iotjs_entry(int argc, char **argv);
+int iotjs_entry(int argc, char** argv);
 int tuv_cleanup(void);
 
 
 #if USE_IOTJS_THREAD
 struct iotjs_thread_arg {
   int argc;
-  char **argv;
+  char** argv;
 };
 
-pthread_addr_t iotjs_thread(void *thread_arg) {
-  struct iotjs_thread_arg *arg = thread_arg;
+pthread_addr_t iotjs_thread(void* thread_arg) {
+  struct iotjs_thread_arg* arg = thread_arg;
 
 #ifdef CONFIG_DEBUG_VERBOSE
   int ret = iotjs_entry(arg->argc, arg->argv);
@@ -126,7 +126,7 @@ pthread_addr_t iotjs_thread(void *thread_arg) {
   return NULL;
 }
 
-int iotjs(int argc, char *argv[]) {
+int iotjs(int argc, char* argv[]) {
   pthread_attr_t attr;
   int status;
   struct sched_param sparam;
@@ -160,7 +160,7 @@ int iotjs(int argc, char *argv[]) {
 
 #else
 
-static int iotjs(int argc, char *argv[]) {
+static int iotjs(int argc, char* argv[]) {
   int ret = 0;
   ret = iotjs_entry(argc, argv);
 #ifdef CONFIG_DEBUG_VERBOSE


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added

See https://clang.llvm.org/docs/ClangFormatStyleOptions.html

**DerivePointerAlignment (bool)**
> If true, analyze the formatted file for the most common alignment of & and *. Pointer and reference
> alignment styles are going to be updated according to the preferences found in the file. 
> PointerAlignment is then used only as fallback.

**PointerAlignment (PointerAlignmentStyle)**
> Pointer and reference alignment style.

Just set the `DerivePointerAlignment` to false to fix our styles.