### PR TITLE
napi: null in-out return pointer

### DIFF
--- a/src/internal/node_api_internal.h
+++ b/src/internal/node_api_internal.h
@@ -90,7 +90,7 @@
 /**
  * In most N-API functions, there is an in-out pointer parameter to retrieve
  * return values, yet this pointer could be NULL anyway - it has to be ensured
- * not write any unexpected value to NULL pointer.
+ * no value were unexpectedly written to NULL pointer.
  */
 #define NAPI_ASSIGN(result, value) \
   if ((result) != NULL)            \

--- a/src/internal/node_api_internal.h
+++ b/src/internal/node_api_internal.h
@@ -25,32 +25,94 @@
 #define AS_JERRY_VALUE(nvalue) (jerry_value_t)(uintptr_t) nvalue
 #define AS_NAPI_VALUE(jval) (napi_value)(uintptr_t) jval
 
-#define NAPI_WEAK_ASSERT(error_t, assertion) \
-  do {                                       \
-    if (!(assertion))                        \
-      return error_t;                        \
+/**
+ * MARK: - N-API Returns machenism:
+ * If any non-napi-ok status code is returned in N-API functions, there
+ * should be an error code and error message temporarily stored in napi-env
+ * and can be fetched by `napi_get_last_error_info` until next napi function
+ * called.
+ */
+#define NAPI_RETURN_WITH_MSG(status, message)                                \
+  {                                                                          \
+    iotjs_napi_set_error_info(iotjs_get_current_napi_env(), status, message, \
+                              0, NULL);                                      \
+    return status;                                                           \
+  }
+
+#define NAPI_RETURN_NO_MSG(status)                                           \
+  {                                                                          \
+    iotjs_napi_set_error_info(iotjs_get_current_napi_env(), status, NULL, 0, \
+                              NULL);                                         \
+    return status;                                                           \
+  }
+
+#define GET_3TH_ARG(arg1, arg2, arg3, ...) arg3
+#define NAPI_RETURN_MACRO_CHOOSER(...) \
+  GET_3TH_ARG(__VA_ARGS__, NAPI_RETURN_WITH_MSG, NAPI_RETURN_NO_MSG, )
+
+#define NAPI_RETURN(...) NAPI_RETURN_MACRO_CHOOSER(__VA_ARGS__)(__VA_ARGS__)
+/** MARK: - END N-API Returns */
+
+/** MARK: - N-API Asserts */
+/**
+ * A weak assertion, which don't crash the program on failed assertion
+ * rather returning a napi error code back to caller.
+ */
+#define NAPI_WEAK_ASSERT(error_t, assertion)                     \
+  do {                                                           \
+    if (!(assertion))                                            \
+      NAPI_RETURN(error_t, "Assertion (" #assertion ") failed"); \
   } while (0)
 
+/**
+ * A convenience weak assertion on jerry value type.
+ */
 #define NAPI_TRY_TYPE(type, jval) \
   NAPI_WEAK_ASSERT(napi_##type##_expected, jerry_value_is_##type(jval))
 
+/**
+ * A convenience weak assertion on N-API Env matching.
+ */
+#define NAPI_TRY_ENV(env)                                 \
+  if (env != iotjs_get_current_napi_env()) {              \
+    NAPI_RETURN(napi_invalid_arg, "N-API env not match.") \
+  }
+
+/**
+ * A convenience weak assertion expecting there is no pending exception
+ * unhandled.
+ */
 #define NAPI_TRY_NO_PENDING_EXCEPTION(env) \
   NAPI_WEAK_ASSERT(napi_pending_exception, \
                    !iotjs_napi_is_exception_pending((iotjs_napi_env_t*)env))
+/** MARK: - N-API Asserts */
 
+/**
+ * In most N-API functions, there is an in-out pointer parameter to retrieve
+ * return values, yet this pointer could be NULL anyway - it has to be ensured
+ * not write any unexpected value to NULL pointer.
+ */
 #define NAPI_ASSIGN(result, value) \
   if ((result) != NULL)            \
     *(result) = (value);
 
+/**
+ * A convenience macro to call N-API functions internally and handle it's
+ * non-napi-ok status code.
+ */
 #define NAPI_INTERNAL_CALL(call) \
   do {                           \
     napi_status status;          \
     status = (call);             \
     if (status != napi_ok) {     \
-      return status;             \
+      NAPI_RETURN(status);       \
     }                            \
   } while (0)
 
+/**
+ * A convenience macro to create jerry-values and add it to current top
+ * handle scope.
+ */
 #define JERRYX_CREATE(var, create) \
   jerry_value_t var = create;      \
   jerryx_create_handle(var);
@@ -61,6 +123,11 @@ int napi_module_init_pending(jerry_value_t* exports);
 
 /** MARK: - node_api_env.c */
 napi_env iotjs_get_current_napi_env();
+void iotjs_napi_set_error_info(napi_env env, napi_status error_code,
+                               const char* error_message,
+                               uint32_t engine_error_code,
+                               void* engine_reserved);
+void iotjs_napi_clear_error_info(napi_env env);
 bool iotjs_napi_is_exception_pending(iotjs_napi_env_t* env);
 jerry_value_t iotjs_napi_env_get_and_clear_exception(napi_env env);
 jerry_value_t iotjs_napi_env_get_and_clear_fatal_exception(napi_env env);

--- a/src/internal/node_api_internal.h
+++ b/src/internal/node_api_internal.h
@@ -36,7 +36,11 @@
 
 #define NAPI_TRY_NO_PENDING_EXCEPTION(env) \
   NAPI_WEAK_ASSERT(napi_pending_exception, \
-                   iotjs_napi_is_exception_pending((iotjs_napi_env_t*)env))
+                   !iotjs_napi_is_exception_pending((iotjs_napi_env_t*)env))
+
+#define NAPI_ASSIGN(result, value) \
+  if ((result) != NULL)            \
+    *(result) = (value);
 
 #define NAPI_INTERNAL_CALL(call) \
   do {                           \

--- a/src/modules/iotjs_module_process.c
+++ b/src/modules/iotjs_module_process.c
@@ -450,7 +450,7 @@ JS_FUNCTION(OpenNativeModule) {
   if (status == napi_module_no_nm_register_func) {
     jerry_value_t jval_error = jerry_create_error(
         JERRY_ERROR_COMMON,
-        (jerry_char_t*)"Native module has no nm_register_func");
+        (jerry_char_t*)"Module has no declared entry point.");
     return jval_error;
   }
 #endif

--- a/src/napi/node_api.c
+++ b/src/napi/node_api.c
@@ -26,10 +26,10 @@ static napi_node_version node_version = {
 napi_status napi_get_node_version(napi_env env,
                                   const napi_node_version** version) {
   NAPI_ASSIGN(version, &node_version);
-  return napi_ok;
+  NAPI_RETURN(napi_ok);
 }
 
 napi_status napi_get_version(napi_env env, uint32_t* result) {
   NAPI_ASSIGN(result, NAPI_VERSION);
-  return napi_ok;
+  NAPI_RETURN(napi_ok);
 }

--- a/src/napi/node_api.c
+++ b/src/napi/node_api.c
@@ -25,11 +25,11 @@ static napi_node_version node_version = {
 
 napi_status napi_get_node_version(napi_env env,
                                   const napi_node_version** version) {
-  *version = &node_version;
+  NAPI_ASSIGN(version, &node_version);
   return napi_ok;
 }
 
 napi_status napi_get_version(napi_env env, uint32_t* result) {
-  *result = NAPI_VERSION;
+  NAPI_ASSIGN(result, NAPI_VERSION);
   return napi_ok;
 }

--- a/src/napi/node_api_env.c
+++ b/src/napi/node_api_env.c
@@ -16,6 +16,8 @@
 #include "iotjs_def.h"
 #include "internal/node_api_internal.h"
 
+static const char* NAPI_GENERIC_ERROR_MESSAGE = "Unexpected error.";
+
 static iotjs_napi_env_t current_env = {
   .pending_exception = NULL,
   .pending_fatal_exception = NULL,
@@ -28,6 +30,31 @@ inline napi_env iotjs_get_current_napi_env() {
 inline bool iotjs_napi_is_exception_pending(iotjs_napi_env_t* env) {
   return !(env->pending_exception == NULL &&
            env->pending_fatal_exception == NULL);
+}
+
+void iotjs_napi_set_error_info(napi_env env, napi_status error_code,
+                               const char* error_message,
+                               uint32_t engine_error_code,
+                               void* engine_reserved) {
+  iotjs_napi_env_t* cur_env = (iotjs_napi_env_t*)env;
+
+  if (error_message == NULL && error_code != napi_ok) {
+    error_message = NAPI_GENERIC_ERROR_MESSAGE;
+  }
+
+  cur_env->extended_error_info.error_code = error_code;
+  cur_env->extended_error_info.error_message = error_message;
+  cur_env->extended_error_info.engine_error_code = engine_error_code;
+  cur_env->extended_error_info.engine_reserved = engine_reserved;
+}
+
+void iotjs_napi_clear_error_info(napi_env env) {
+  iotjs_napi_env_t* cur_env = (iotjs_napi_env_t*)env;
+
+  cur_env->extended_error_info.error_code = napi_ok;
+  cur_env->extended_error_info.error_message = NULL;
+  cur_env->extended_error_info.engine_error_code = 0;
+  cur_env->extended_error_info.engine_reserved = NULL;
 }
 
 jerry_value_t iotjs_napi_env_get_and_clear_exception(napi_env env) {
@@ -50,11 +77,9 @@ jerry_value_t iotjs_napi_env_get_and_clear_fatal_exception(napi_env env) {
 
 // Methods to support error handling
 napi_status napi_throw(napi_env env, napi_value error) {
-  if (env != iotjs_get_current_napi_env())
-    return napi_invalid_arg;
+  NAPI_TRY_ENV(env);
   iotjs_napi_env_t* curr_env = (iotjs_napi_env_t*)env;
-  if (iotjs_napi_is_exception_pending(curr_env))
-    return napi_pending_exception;
+  NAPI_TRY_NO_PENDING_EXCEPTION(curr_env);
 
   jerry_value_t jval_err = AS_JERRY_VALUE(error);
   if (!jerry_value_has_error_flag(jval_err)) {
@@ -62,16 +87,17 @@ napi_status napi_throw(napi_env env, napi_value error) {
   }
 
   curr_env->pending_exception = AS_NAPI_VALUE(jval_err);
-  return napi_ok;
+  NAPI_RETURN(napi_ok);
 }
 
 #define DEF_NAPI_THROWS(type, jerry_error_type)                   \
   napi_status napi_throw_##type(napi_env env, const char* code,   \
                                 const char* msg) {                \
-    if (env != iotjs_get_current_napi_env())                      \
-      return napi_invalid_arg;                                    \
-    if (iotjs_napi_is_exception_pending((iotjs_napi_env_t*)env))  \
-      return napi_pending_exception;                              \
+    NAPI_TRY_ENV(env);                                            \
+    NAPI_TRY_NO_PENDING_EXCEPTION(env);                           \
+                                                                  \
+    NAPI_WEAK_ASSERT(napi_invalid_arg, msg != NULL);              \
+    NAPI_WEAK_ASSERT(napi_invalid_arg, code != NULL);             \
                                                                   \
     jerry_value_t jval_error =                                    \
         jerry_create_error(jerry_error_type, (jerry_char_t*)msg); \
@@ -85,11 +111,9 @@ DEF_NAPI_THROWS(range_error, JERRY_ERROR_RANGE);
 #undef DEF_NAPI_THROWS
 
 napi_status napi_fatal_exception(napi_env env, napi_value err) {
-  if (env != iotjs_get_current_napi_env())
-    return napi_invalid_arg;
+  NAPI_TRY_ENV(env);
+  NAPI_TRY_NO_PENDING_EXCEPTION(env);
   iotjs_napi_env_t* curr_env = (iotjs_napi_env_t*)env;
-  if (iotjs_napi_is_exception_pending(curr_env))
-    return napi_pending_exception;
 
   jerry_value_t jval_err = AS_JERRY_VALUE(err);
   if (!jerry_value_has_error_flag(jval_err)) {
@@ -97,22 +121,20 @@ napi_status napi_fatal_exception(napi_env env, napi_value err) {
   }
 
   curr_env->pending_fatal_exception = AS_NAPI_VALUE(jval_err);
-  return napi_ok;
+  NAPI_RETURN(napi_ok);
 }
 
 
 // Methods to support catching exceptions
 napi_status napi_is_exception_pending(napi_env env, bool* result) {
-  if (env != iotjs_get_current_napi_env())
-    return napi_invalid_arg;
+  NAPI_TRY_ENV(env);
   NAPI_ASSIGN(result, iotjs_napi_is_exception_pending((iotjs_napi_env_t*)env));
-  return napi_ok;
+  NAPI_RETURN(napi_ok);
 }
 
 napi_status napi_get_and_clear_last_exception(napi_env env,
                                               napi_value* result) {
-  if (env != iotjs_get_current_napi_env())
-    return napi_invalid_arg;
+  NAPI_TRY_ENV(env);
   iotjs_napi_env_t* curr_env = (iotjs_napi_env_t*)env;
 
   if (curr_env->pending_exception != NULL) {
@@ -122,14 +144,13 @@ napi_status napi_get_and_clear_last_exception(napi_env env,
     NAPI_ASSIGN(result, curr_env->pending_fatal_exception);
     curr_env->pending_fatal_exception = NULL;
   }
-  return napi_ok;
+  NAPI_RETURN(napi_ok);
 }
 
 
 napi_status napi_get_last_error_info(napi_env env,
                                      const napi_extended_error_info** result) {
-  if (env != iotjs_get_current_napi_env())
-    return napi_invalid_arg;
+  NAPI_TRY_ENV(env);
   iotjs_napi_env_t* curr_env = (iotjs_napi_env_t*)env;
   napi_extended_error_info* error_info = &curr_env->extended_error_info;
 

--- a/src/napi/node_api_env.c
+++ b/src/napi/node_api_env.c
@@ -105,7 +105,7 @@ napi_status napi_fatal_exception(napi_env env, napi_value err) {
 napi_status napi_is_exception_pending(napi_env env, bool* result) {
   if (env != iotjs_get_current_napi_env())
     return napi_invalid_arg;
-  *result = iotjs_napi_is_exception_pending((iotjs_napi_env_t*)env);
+  NAPI_ASSIGN(result, iotjs_napi_is_exception_pending((iotjs_napi_env_t*)env));
   return napi_ok;
 }
 
@@ -116,10 +116,10 @@ napi_status napi_get_and_clear_last_exception(napi_env env,
   iotjs_napi_env_t* curr_env = (iotjs_napi_env_t*)env;
 
   if (curr_env->pending_exception != NULL) {
-    *result = curr_env->pending_exception;
+    NAPI_ASSIGN(result, curr_env->pending_exception);
     curr_env->pending_exception = NULL;
   } else if (curr_env->pending_fatal_exception != NULL) {
-    *result = curr_env->pending_fatal_exception;
+    NAPI_ASSIGN(result, curr_env->pending_fatal_exception);
     curr_env->pending_fatal_exception = NULL;
   }
   return napi_ok;
@@ -133,6 +133,6 @@ napi_status napi_get_last_error_info(napi_env env,
   iotjs_napi_env_t* curr_env = (iotjs_napi_env_t*)env;
   napi_extended_error_info* error_info = &curr_env->extended_error_info;
 
-  *result = error_info;
+  NAPI_ASSIGN(result, error_info);
   return napi_ok;
 }

--- a/src/napi/node_api_function.c
+++ b/src/napi/node_api_function.c
@@ -71,6 +71,11 @@ static jerry_value_t iotjs_napi_function_handler(
 
 cleanup:
   jerryx_close_handle_scope(scope);
+  /**
+   * Clear N-API env extended error info on end of external function
+   * execution to prevent error info been passed to next external function.
+   */
+  iotjs_napi_clear_error_info(env);
   return jval_ret;
 }
 
@@ -90,7 +95,7 @@ napi_status napi_create_function(napi_env env, const char* utf8name,
                                   &native_obj_type_info);
 
   NAPI_ASSIGN(result, AS_NAPI_VALUE(jval_func));
-  return napi_ok;
+  NAPI_RETURN(napi_ok);
 }
 
 napi_status napi_call_function(napi_env env, napi_value recv, napi_value func,
@@ -108,11 +113,12 @@ napi_status napi_call_function(napi_env env, napi_value recv, napi_value func,
   jerryx_create_handle(jval_ret);
   if (jerry_value_has_error_flag(jval_ret)) {
     NAPI_INTERNAL_CALL(napi_throw(env, AS_NAPI_VALUE(jval_ret)));
-    return napi_generic_failure;
+    NAPI_RETURN(napi_generic_failure,
+                "Unexpected error flag on jerry_call_function.");
   }
 
   NAPI_ASSIGN(result, AS_NAPI_VALUE(jval_ret));
-  return napi_ok;
+  NAPI_RETURN(napi_ok);
 }
 
 napi_status napi_get_cb_info(napi_env env, napi_callback_info cbinfo,
@@ -139,7 +145,7 @@ napi_status napi_get_cb_info(napi_env env, napi_callback_info cbinfo,
     NAPI_ASSIGN(data, callback_info->function_info->data);
   }
 
-  return napi_ok;
+  NAPI_RETURN(napi_ok);
 }
 
 napi_status napi_new_instance(napi_env env, napi_value constructor, size_t argc,
@@ -155,9 +161,10 @@ napi_status napi_new_instance(napi_env env, napi_value constructor, size_t argc,
   jerryx_create_handle(jval_ret);
   if (jerry_value_has_error_flag(jval_ret)) {
     NAPI_INTERNAL_CALL(napi_throw(env, AS_NAPI_VALUE(jval_ret)));
-    return napi_generic_failure;
+    NAPI_RETURN(napi_generic_failure,
+                "Unexpected error flag on jerry_construct_object.");
   }
 
   NAPI_ASSIGN(result, AS_NAPI_VALUE(jval_ret));
-  return napi_ok;
+  NAPI_RETURN(napi_ok);
 }

--- a/src/napi/node_api_function.c
+++ b/src/napi/node_api_function.c
@@ -89,7 +89,7 @@ napi_status napi_create_function(napi_env env, const char* utf8name,
   jerry_set_object_native_pointer(jval_func, function_info,
                                   &native_obj_type_info);
 
-  *result = AS_NAPI_VALUE(jval_func);
+  NAPI_ASSIGN(result, AS_NAPI_VALUE(jval_func));
   return napi_ok;
 }
 
@@ -111,7 +111,7 @@ napi_status napi_call_function(napi_env env, napi_value recv, napi_value func,
     return napi_generic_failure;
   }
 
-  *result = AS_NAPI_VALUE(jval_ret);
+  NAPI_ASSIGN(result, AS_NAPI_VALUE(jval_ret));
   return napi_ok;
 }
 
@@ -122,17 +122,22 @@ napi_status napi_get_cb_info(napi_env env, napi_callback_info cbinfo,
 
   NAPI_WEAK_ASSERT(napi_invalid_arg, (argc != NULL));
 
-  for (size_t i = 0; i < *argc && i < callback_info->argc; ++i) {
-    if ((argv + i) != NULL)
-      argv[i] = AS_NAPI_VALUE(callback_info->argv[i]);
+  for (size_t i = 0; i < *argc; ++i) {
+    if (i < callback_info->argc) {
+      NAPI_ASSIGN(argv + i, AS_NAPI_VALUE(callback_info->argv[i]));
+    } else {
+      NAPI_ASSIGN(argv + i, AS_NAPI_VALUE(jerry_create_undefined()));
+    }
   }
-  *argc = callback_info->argc;
+  NAPI_ASSIGN(argc, callback_info->argc);
 
-  if (thisArg != NULL)
-    *thisArg = AS_NAPI_VALUE(callback_info->jval_this);
+  if (thisArg != NULL) {
+    NAPI_ASSIGN(thisArg, AS_NAPI_VALUE(callback_info->jval_this));
+  }
 
-  if (data != NULL)
-    *data = callback_info->function_info->data;
+  if (data != NULL) {
+    NAPI_ASSIGN(data, callback_info->function_info->data);
+  }
 
   return napi_ok;
 }
@@ -153,6 +158,6 @@ napi_status napi_new_instance(napi_env env, napi_value constructor, size_t argc,
     return napi_generic_failure;
   }
 
-  *result = AS_NAPI_VALUE(jval_ret);
+  NAPI_ASSIGN(result, AS_NAPI_VALUE(jval_ret));
   return napi_ok;
 }

--- a/src/napi/node_api_lifetime.c
+++ b/src/napi/node_api_lifetime.c
@@ -37,11 +37,11 @@ inline napi_status jerryx_status_to_napi_status(
     jerryx_handle_scope_status status) {
   switch (status) {
     case jerryx_handle_scope_mismatch:
-      return napi_handle_scope_mismatch;
+      NAPI_RETURN(napi_handle_scope_mismatch, NULL);
     case jerryx_escape_called_twice:
-      return napi_escape_called_twice;
+      NAPI_RETURN(napi_escape_called_twice, NULL);
     default:
-      return napi_ok;
+      NAPI_RETURN(napi_ok);
   }
 }
 
@@ -129,7 +129,7 @@ napi_status napi_create_reference(napi_env env, napi_value value,
   info->ref = ref;
 
   *result = (napi_ref)ref;
-  return napi_ok;
+  NAPI_RETURN(napi_ok);
 }
 
 napi_status napi_delete_reference(napi_env env, napi_ref ref) {
@@ -147,7 +147,7 @@ napi_status napi_delete_reference(napi_env env, napi_ref ref) {
     jerry_release_value(iot_ref->jval);
   }
   free(iot_ref);
-  return napi_ok;
+  NAPI_RETURN(napi_ok);
 }
 
 napi_status napi_reference_ref(napi_env env, napi_ref ref, uint32_t* result) {
@@ -158,7 +158,7 @@ napi_status napi_reference_ref(napi_env env, napi_ref ref, uint32_t* result) {
   iot_ref->refcount += 1;
 
   NAPI_ASSIGN(result, iot_ref->refcount);
-  return napi_ok;
+  NAPI_RETURN(napi_ok);
 }
 
 napi_status napi_reference_unref(napi_env env, napi_ref ref, uint32_t* result) {
@@ -169,12 +169,12 @@ napi_status napi_reference_unref(napi_env env, napi_ref ref, uint32_t* result) {
   iot_ref->refcount -= 1;
 
   NAPI_ASSIGN(result, iot_ref->refcount);
-  return napi_ok;
+  NAPI_RETURN(napi_ok);
 }
 
 napi_status napi_get_reference_value(napi_env env, napi_ref ref,
                                      napi_value* result) {
   iotjs_reference_t* iot_ref = (iotjs_reference_t*)ref;
   NAPI_ASSIGN(result, AS_NAPI_VALUE(iot_ref->jval));
-  return napi_ok;
+  NAPI_RETURN(napi_ok);
 }

--- a/src/napi/node_api_lifetime.c
+++ b/src/napi/node_api_lifetime.c
@@ -62,6 +62,8 @@ iotjs_object_info_t* iotjs_get_object_native_info(jerry_value_t jval,
 }
 
 napi_status napi_open_handle_scope(napi_env env, napi_handle_scope* result) {
+  NAPI_WEAK_ASSERT(napi_invalid_arg, result != NULL);
+
   jerryx_handle_scope_status status;
   status = jerryx_open_handle_scope((jerryx_handle_scope*)result);
 
@@ -70,6 +72,8 @@ napi_status napi_open_handle_scope(napi_env env, napi_handle_scope* result) {
 
 napi_status napi_open_escapable_handle_scope(
     napi_env env, napi_escapable_handle_scope* result) {
+  NAPI_WEAK_ASSERT(napi_invalid_arg, result != NULL);
+
   jerryx_handle_scope_status status;
   status = jerryx_open_escapable_handle_scope(
       (jerryx_escapable_handle_scope*)result);
@@ -95,6 +99,8 @@ napi_status napi_close_escapable_handle_scope(
 
 napi_status napi_escape_handle(napi_env env, napi_escapable_handle_scope scope,
                                napi_value escapee, napi_value* result) {
+  NAPI_WEAK_ASSERT(napi_invalid_arg, result != NULL);
+
   jerryx_handle_scope_status status;
   status =
       jerryx_escape_handle((jerryx_escapable_handle_scope)scope,
@@ -105,6 +111,8 @@ napi_status napi_escape_handle(napi_env env, napi_escapable_handle_scope scope,
 
 napi_status napi_create_reference(napi_env env, napi_value value,
                                   uint32_t initial_refcount, napi_ref* result) {
+  NAPI_WEAK_ASSERT(napi_invalid_arg, result != NULL);
+
   jerry_value_t jval = AS_JERRY_VALUE(value);
   iotjs_object_info_t* info;
   bool has_native_ptr =
@@ -149,7 +157,7 @@ napi_status napi_reference_ref(napi_env env, napi_ref ref, uint32_t* result) {
   jerry_acquire_value(iot_ref->jval);
   iot_ref->refcount += 1;
 
-  *result = iot_ref->refcount;
+  NAPI_ASSIGN(result, iot_ref->refcount);
   return napi_ok;
 }
 
@@ -160,13 +168,13 @@ napi_status napi_reference_unref(napi_env env, napi_ref ref, uint32_t* result) {
   jerry_release_value(iot_ref->jval);
   iot_ref->refcount -= 1;
 
-  *result = iot_ref->refcount;
+  NAPI_ASSIGN(result, iot_ref->refcount);
   return napi_ok;
 }
 
 napi_status napi_get_reference_value(napi_env env, napi_ref ref,
                                      napi_value* result) {
   iotjs_reference_t* iot_ref = (iotjs_reference_t*)ref;
-  *result = AS_NAPI_VALUE(iot_ref->jval);
+  NAPI_ASSIGN(result, AS_NAPI_VALUE(iot_ref->jval));
   return napi_ok;
 }

--- a/src/napi/node_api_module.c
+++ b/src/napi/node_api_module.c
@@ -38,11 +38,10 @@ int napi_module_init_pending(jerry_value_t* exports) {
 
   napi_env env = iotjs_get_current_napi_env();
 
-  jerryx_escapable_handle_scope scope;
-  jerryx_open_escapable_handle_scope(&scope);
+  jerryx_handle_scope scope;
+  jerryx_open_handle_scope(&scope);
 
   jerry_value_t jval_exports = jerry_create_object();
-  jerryx_create_handle(jval_exports);
   napi_value nvalue_ret = (*Init)(env, jval_exports);
 
   if (nvalue_ret == NULL) {
@@ -52,8 +51,9 @@ int napi_module_init_pending(jerry_value_t* exports) {
     jerry_value_t jval_ret = AS_JERRY_VALUE(nvalue_ret);
     if (jval_ret != jval_exports) {
       jerry_release_value(jval_exports);
+      jerryx_remove_handle(scope, jval_ret, &jval_ret);
     }
-    jerryx_remove_handle(scope, jval_ret, exports);
+    *exports = jval_ret;
   }
 
   jerryx_close_handle_scope(scope);

--- a/src/napi/node_api_object_wrap.c
+++ b/src/napi/node_api_object_wrap.c
@@ -21,6 +21,8 @@ napi_status napi_define_class(napi_env env, const char* utf8name, size_t length,
                               size_t property_count,
                               const napi_property_descriptor* properties,
                               napi_value* result) {
+  NAPI_WEAK_ASSERT(napi_invalid_arg, properties != NULL);
+
   napi_value nval;
   NAPI_INTERNAL_CALL(
       napi_create_function(env, utf8name, length, constructor, data, &nval));
@@ -37,6 +39,8 @@ napi_status napi_define_class(napi_env env, const char* utf8name, size_t length,
     }
   }
 
+  NAPI_ASSIGN(result, nval);
+
   return napi_ok;
 }
 
@@ -44,6 +48,8 @@ napi_status napi_wrap(napi_env env, napi_value js_object, void* native_object,
                       napi_finalize finalize_cb, void* finalize_hint,
                       napi_ref* result) {
   jerry_value_t jval = AS_JERRY_VALUE(js_object);
+  NAPI_TRY_TYPE(object, jval);
+
   iotjs_object_info_t* object_info =
       iotjs_get_object_native_info(jval, sizeof(iotjs_object_info_t));
 
@@ -61,10 +67,12 @@ napi_status napi_wrap(napi_env env, napi_value js_object, void* native_object,
 
 napi_status napi_unwrap(napi_env env, napi_value js_object, void** result) {
   jerry_value_t jval = AS_JERRY_VALUE(js_object);
+  NAPI_TRY_TYPE(object, jval);
+
   iotjs_object_info_t* object_info =
       iotjs_get_object_native_info(jval, sizeof(iotjs_object_info_t));
 
-  *result = object_info->native_object;
+  NAPI_ASSIGN(result, object_info->native_object);
   return napi_ok;
 }
 
@@ -73,6 +81,8 @@ napi_status napi_remove_wrap(napi_env env, napi_value js_object,
   jerry_value_t jval = AS_JERRY_VALUE(js_object);
   iotjs_object_info_t* object_info =
       iotjs_get_object_native_info(jval, sizeof(iotjs_object_info_t));
+
+  NAPI_ASSIGN(result, object_info->native_object);
 
   object_info->native_object = NULL;
   object_info->finalize_cb = NULL;

--- a/src/napi/node_api_object_wrap.c
+++ b/src/napi/node_api_object_wrap.c
@@ -41,7 +41,7 @@ napi_status napi_define_class(napi_env env, const char* utf8name, size_t length,
 
   NAPI_ASSIGN(result, nval);
 
-  return napi_ok;
+  NAPI_RETURN(napi_ok);
 }
 
 napi_status napi_wrap(napi_env env, napi_value js_object, void* native_object,
@@ -73,7 +73,7 @@ napi_status napi_unwrap(napi_env env, napi_value js_object, void** result) {
       iotjs_get_object_native_info(jval, sizeof(iotjs_object_info_t));
 
   NAPI_ASSIGN(result, object_info->native_object);
-  return napi_ok;
+  NAPI_RETURN(napi_ok);
 }
 
 napi_status napi_remove_wrap(napi_env env, napi_value js_object,
@@ -88,5 +88,5 @@ napi_status napi_remove_wrap(napi_env env, napi_value js_object,
   object_info->finalize_cb = NULL;
   object_info->finalize_hint = NULL;
 
-  return napi_ok;
+  NAPI_RETURN(napi_ok);
 }

--- a/src/napi/node_api_property.c
+++ b/src/napi/node_api_property.c
@@ -27,7 +27,7 @@ napi_status napi_get_property_names(napi_env env, napi_value object,
   if (jerry_value_has_error_flag(jval_keys))
     return napi_invalid_arg;
 
-  *result = AS_NAPI_VALUE(jval_keys);
+  NAPI_ASSIGN(result, AS_NAPI_VALUE(jval_keys));
   return napi_ok;
 }
 
@@ -63,7 +63,7 @@ napi_status napi_get_property(napi_env env, napi_value object, napi_value key,
   if (jerry_value_has_error_flag(jval_ret))
     return napi_invalid_arg;
 
-  *result = AS_NAPI_VALUE(jval_ret);
+  NAPI_ASSIGN(result, AS_NAPI_VALUE(jval_ret));
   return napi_ok;
 }
 
@@ -75,7 +75,7 @@ napi_status napi_has_property(napi_env env, napi_value object, napi_value key,
   NAPI_TRY_TYPE(object, jval_object);
   NAPI_TRY_TYPE(string, jval_key);
 
-  *result = jerry_has_property(jval_object, jval_key);
+  NAPI_ASSIGN(result, jerry_has_property(jval_object, jval_key));
 
   return napi_ok;
 }
@@ -88,7 +88,7 @@ napi_status napi_delete_property(napi_env env, napi_value object,
   NAPI_TRY_TYPE(object, jval_object);
   NAPI_TRY_TYPE(string, jval_key);
 
-  *result = jerry_delete_property(jval_object, jval_key);
+  NAPI_ASSIGN(result, jerry_delete_property(jval_object, jval_key));
   return napi_ok;
 }
 
@@ -100,7 +100,7 @@ napi_status napi_has_own_property(napi_env env, napi_value object,
   NAPI_TRY_TYPE(object, jval_object);
   NAPI_TRY_TYPE(string, jval_key);
 
-  *result = jerry_has_own_property(jval_object, jval_key);
+  NAPI_ASSIGN(result, jerry_has_own_property(jval_object, jval_key));
   return napi_ok;
 }
 
@@ -171,7 +171,7 @@ napi_status napi_get_element(napi_env env, napi_value object, uint32_t index,
   if (jerry_value_has_error_flag(jval_ret)) {
     return napi_invalid_arg;
   }
-  *result = AS_NAPI_VALUE(jval_ret);
+  NAPI_ASSIGN(result, AS_NAPI_VALUE(jval_ret));
   return napi_ok;
 }
 
@@ -180,7 +180,7 @@ napi_status napi_has_element(napi_env env, napi_value object, uint32_t index,
   jerry_value_t jval_object = AS_JERRY_VALUE(object);
   NAPI_TRY_TYPE(object, jval_object);
 
-  *result = jerry_has_property_by_index(jval_object, index);
+  NAPI_ASSIGN(result, jerry_has_property_by_index(jval_object, index));
   return napi_ok;
 }
 
@@ -189,7 +189,7 @@ napi_status napi_delete_element(napi_env env, napi_value object, uint32_t index,
   jerry_value_t jval_object = AS_JERRY_VALUE(object);
   NAPI_TRY_TYPE(object, jval_object);
 
-  *result = jerry_delete_property_by_index(jval_object, index);
+  NAPI_ASSIGN(result, jerry_delete_property_by_index(jval_object, index));
   return napi_ok;
 }
 
@@ -252,6 +252,7 @@ napi_status napi_define_properties(napi_env env, napi_value object,
                                    const napi_property_descriptor* properties) {
   jerry_value_t jval_target = AS_JERRY_VALUE(object);
   NAPI_TRY_TYPE(object, jval_target);
+  NAPI_WEAK_ASSERT(napi_invalid_arg, properties != NULL);
 
   napi_status status;
   jerry_property_descriptor_t prop_desc;

--- a/src/napi/node_api_property.c
+++ b/src/napi/node_api_property.c
@@ -25,10 +25,10 @@ napi_status napi_get_property_names(napi_env env, napi_value object,
   jerry_value_t jval_keys = jerry_get_object_keys(jval);
   jerryx_create_handle(jval_keys);
   if (jerry_value_has_error_flag(jval_keys))
-    return napi_invalid_arg;
+    NAPI_RETURN(napi_invalid_arg, NULL);
 
   NAPI_ASSIGN(result, AS_NAPI_VALUE(jval_keys));
-  return napi_ok;
+  NAPI_RETURN(napi_ok);
 }
 
 napi_status napi_set_property(napi_env env, napi_value object, napi_value key,
@@ -43,11 +43,11 @@ napi_status napi_set_property(napi_env env, napi_value object, napi_value key,
   jerry_value_t ret = jerry_set_property(jval_object, jval_key, jval_val);
   if (jerry_value_has_error_flag(ret)) {
     jerry_release_value(ret);
-    return napi_invalid_arg;
+    NAPI_RETURN(napi_invalid_arg, NULL);
   }
 
   jerry_release_value(ret);
-  return napi_ok;
+  NAPI_RETURN(napi_ok);
 }
 
 napi_status napi_get_property(napi_env env, napi_value object, napi_value key,
@@ -61,10 +61,10 @@ napi_status napi_get_property(napi_env env, napi_value object, napi_value key,
   jerry_value_t jval_ret = jerry_get_property(jval_object, jval_key);
   jerryx_create_handle(jval_ret);
   if (jerry_value_has_error_flag(jval_ret))
-    return napi_invalid_arg;
+    NAPI_RETURN(napi_invalid_arg, NULL);
 
   NAPI_ASSIGN(result, AS_NAPI_VALUE(jval_ret));
-  return napi_ok;
+  NAPI_RETURN(napi_ok);
 }
 
 napi_status napi_has_property(napi_env env, napi_value object, napi_value key,
@@ -77,7 +77,7 @@ napi_status napi_has_property(napi_env env, napi_value object, napi_value key,
 
   NAPI_ASSIGN(result, jerry_has_property(jval_object, jval_key));
 
-  return napi_ok;
+  NAPI_RETURN(napi_ok);
 }
 
 napi_status napi_delete_property(napi_env env, napi_value object,
@@ -89,7 +89,7 @@ napi_status napi_delete_property(napi_env env, napi_value object,
   NAPI_TRY_TYPE(string, jval_key);
 
   NAPI_ASSIGN(result, jerry_delete_property(jval_object, jval_key));
-  return napi_ok;
+  NAPI_RETURN(napi_ok);
 }
 
 napi_status napi_has_own_property(napi_env env, napi_value object,
@@ -101,7 +101,7 @@ napi_status napi_has_own_property(napi_env env, napi_value object,
   NAPI_TRY_TYPE(string, jval_key);
 
   NAPI_ASSIGN(result, jerry_has_own_property(jval_object, jval_key));
-  return napi_ok;
+  NAPI_RETURN(napi_ok);
 }
 
 napi_status napi_set_named_property(napi_env env, napi_value object,
@@ -153,11 +153,11 @@ napi_status napi_set_element(napi_env env, napi_value object, uint32_t index,
   jerry_value_t res = jerry_set_property_by_index(jval_object, index, jval_val);
   if (jerry_value_has_error_flag(res)) {
     jerry_release_value(res);
-    return napi_invalid_arg;
+    NAPI_RETURN(napi_invalid_arg, NULL);
   }
 
   jerry_release_value(res);
-  return napi_ok;
+  NAPI_RETURN(napi_ok);
 }
 
 napi_status napi_get_element(napi_env env, napi_value object, uint32_t index,
@@ -169,10 +169,10 @@ napi_status napi_get_element(napi_env env, napi_value object, uint32_t index,
   jerry_value_t jval_ret = jerry_get_property_by_index(jval_object, index);
   jerryx_create_handle(jval_ret);
   if (jerry_value_has_error_flag(jval_ret)) {
-    return napi_invalid_arg;
+    NAPI_RETURN(napi_invalid_arg, NULL);
   }
   NAPI_ASSIGN(result, AS_NAPI_VALUE(jval_ret));
-  return napi_ok;
+  NAPI_RETURN(napi_ok);
 }
 
 napi_status napi_has_element(napi_env env, napi_value object, uint32_t index,
@@ -181,7 +181,7 @@ napi_status napi_has_element(napi_env env, napi_value object, uint32_t index,
   NAPI_TRY_TYPE(object, jval_object);
 
   NAPI_ASSIGN(result, jerry_has_property_by_index(jval_object, index));
-  return napi_ok;
+  NAPI_RETURN(napi_ok);
 }
 
 napi_status napi_delete_element(napi_env env, napi_value object, uint32_t index,
@@ -190,7 +190,7 @@ napi_status napi_delete_element(napi_env env, napi_value object, uint32_t index,
   NAPI_TRY_TYPE(object, jval_object);
 
   NAPI_ASSIGN(result, jerry_delete_property_by_index(jval_object, index));
-  return napi_ok;
+  NAPI_RETURN(napi_ok);
 }
 
 napi_status iotjs_napi_prop_desc_to_jdesc(napi_env env,
@@ -212,7 +212,7 @@ napi_status iotjs_napi_prop_desc_to_jdesc(napi_env env,
   if (ndesc->value != NULL) {
     jdesc->is_value_defined = true;
     jdesc->value = AS_JERRY_VALUE(ndesc->value);
-    return napi_ok;
+    NAPI_RETURN(napi_ok);
   }
 
   if (ndesc->method != NULL) {
@@ -223,7 +223,7 @@ napi_status iotjs_napi_prop_desc_to_jdesc(napi_env env,
       return status;
     jdesc->is_value_defined = true;
     jdesc->value = AS_JERRY_VALUE(method);
-    return napi_ok;
+    NAPI_RETURN(napi_ok);
   }
 
 #define JACCESSOR_FROM_NAPI_ATTR(access)                                       \
@@ -244,7 +244,7 @@ napi_status iotjs_napi_prop_desc_to_jdesc(napi_env env,
 
 #undef JACCESSOR_FROM_NAPI_ATTR
 
-  return napi_ok;
+  NAPI_RETURN(napi_ok);
 }
 
 napi_status napi_define_properties(napi_env env, napi_value object,
@@ -269,7 +269,7 @@ napi_status napi_define_properties(napi_env env, napi_value object,
       jval_prop_name = AS_JERRY_VALUE(prop.name);
       NAPI_TRY_TYPE(string, jval_prop_name);
     } else {
-      return napi_invalid_arg;
+      NAPI_RETURN(napi_invalid_arg, NULL);
     }
 
     status = iotjs_napi_prop_desc_to_jdesc(env, &prop, &prop_desc);
@@ -279,8 +279,7 @@ napi_status napi_define_properties(napi_env env, napi_value object,
     jerry_value_t return_value =
         jerry_define_own_property(jval_target, jval_prop_name, &prop_desc);
     if (jerry_value_has_error_flag(return_value)) {
-      // TODO: collect error info
-      return napi_invalid_arg;
+      NAPI_RETURN(napi_invalid_arg, NULL);
     }
     jerry_release_value(return_value);
 
@@ -291,5 +290,5 @@ napi_status napi_define_properties(napi_env env, napi_value object,
     // jerry_free_property_descriptor_fields(&prop_desc);
   }
 
-  return napi_ok;
+  NAPI_RETURN(napi_ok);
 }

--- a/src/napi/node_api_value.c
+++ b/src/napi/node_api_value.c
@@ -20,27 +20,26 @@
 napi_status napi_create_array(napi_env env, napi_value* result) {
   JERRYX_CREATE(jval, jerry_create_array(0));
   NAPI_ASSIGN(result, AS_NAPI_VALUE(jval));
-  return napi_ok;
+  NAPI_RETURN(napi_ok);
 }
 
 napi_status napi_create_array_with_length(napi_env env, size_t length,
                                           napi_value* result) {
   JERRYX_CREATE(jval, jerry_create_array(length));
   NAPI_ASSIGN(result, AS_NAPI_VALUE(jval));
-  return napi_ok;
+  NAPI_RETURN(napi_ok);
 }
 
 napi_status napi_create_object(napi_env env, napi_value* result) {
   JERRYX_CREATE(jval, jerry_create_object());
   NAPI_ASSIGN(result, AS_NAPI_VALUE(jval));
-  return napi_ok;
+  NAPI_RETURN(napi_ok);
 }
 
 #define DEF_NAPI_CREATE_ERROR(type, jerry_error_type)                         \
   napi_status napi_create_##type(napi_env env, napi_value code,               \
                                  napi_value msg, napi_value* result) {        \
-    if (env != iotjs_get_current_napi_env())                                  \
-      return napi_invalid_arg;                                                \
+    NAPI_TRY_ENV(env);                                                        \
                                                                               \
     jerry_value_t jval_code = AS_JERRY_VALUE(code);                           \
     jerry_value_t jval_msg = AS_JERRY_VALUE(msg);                             \
@@ -60,7 +59,7 @@ napi_status napi_create_object(napi_env env, napi_value* result) {
     iotjs_jval_set_property_jval(jval_error, "code", jval_code);              \
     NAPI_ASSIGN(result, AS_NAPI_VALUE(jval_error));                           \
                                                                               \
-    return napi_ok;                                                           \
+    NAPI_RETURN(napi_ok);                                                     \
   }
 
 DEF_NAPI_CREATE_ERROR(error, JERRY_ERROR_COMMON);
@@ -73,7 +72,7 @@ DEF_NAPI_CREATE_ERROR(range_error, JERRY_ERROR_RANGE);
                                  napi_value* result) {       \
     JERRYX_CREATE(jval, jerry_create_number((double)value)); \
     NAPI_ASSIGN(result, AS_NAPI_VALUE(jval));                \
-    return napi_ok;                                          \
+    NAPI_RETURN(napi_ok);                                    \
   }
 
 DEF_NAPI_NUMBER_CONVERT_FROM_C_TYPE(int32_t, int32);
@@ -89,7 +88,7 @@ DEF_NAPI_NUMBER_CONVERT_FROM_C_TYPE(double, double);
     NAPI_TRY_TYPE(number, jval);                                    \
     double num_val = jerry_get_number_value(jval);                  \
     NAPI_ASSIGN(result, num_val);                                   \
-    return napi_ok;                                                 \
+    NAPI_RETURN(napi_ok);                                           \
   }
 
 DEF_NAPI_NUMBER_CONVERT_FROM_NVALUE(double, double);
@@ -106,14 +105,14 @@ napi_status napi_create_string_utf8(napi_env env, const char* str,
   JERRYX_CREATE(jval,
                 jerry_create_string_sz_from_utf8((jerry_char_t*)str, length));
   NAPI_ASSIGN(result, AS_NAPI_VALUE(jval));
-  return napi_ok;
+  NAPI_RETURN(napi_ok);
 }
 
 napi_status napi_get_array_length(napi_env env, napi_value value,
                                   uint32_t* result) {
   jerry_value_t jval = AS_JERRY_VALUE(value);
   NAPI_ASSIGN(result, jerry_get_array_length(jval));
-  return napi_ok;
+  NAPI_RETURN(napi_ok);
 }
 
 napi_status napi_get_prototype(napi_env env, napi_value object,
@@ -121,38 +120,38 @@ napi_status napi_get_prototype(napi_env env, napi_value object,
   jerry_value_t jval = AS_JERRY_VALUE(object);
   JERRYX_CREATE(jval_proto, jerry_get_prototype(jval));
   NAPI_ASSIGN(result, AS_NAPI_VALUE(jval_proto));
-  return napi_ok;
+  NAPI_RETURN(napi_ok);
 }
 
 napi_status napi_get_value_bool(napi_env env, napi_value value, bool* result) {
   jerry_value_t jval = AS_JERRY_VALUE(value);
   NAPI_TRY_TYPE(boolean, jval);
   NAPI_ASSIGN(result, jerry_get_boolean_value(jval));
-  return napi_ok;
+  NAPI_RETURN(napi_ok);
 }
 
 napi_status napi_get_boolean(napi_env env, bool value, napi_value* result) {
   JERRYX_CREATE(jval, jerry_create_boolean(value));
   NAPI_ASSIGN(result, AS_NAPI_VALUE(jval));
-  return napi_ok;
+  NAPI_RETURN(napi_ok);
 }
 
 napi_status napi_get_global(napi_env env, napi_value* result) {
   JERRYX_CREATE(jval, jerry_get_global_object());
   NAPI_ASSIGN(result, AS_NAPI_VALUE(jval));
-  return napi_ok;
+  NAPI_RETURN(napi_ok);
 }
 
 napi_status napi_get_null(napi_env env, napi_value* result) {
   JERRYX_CREATE(jval, jerry_create_null());
   NAPI_ASSIGN(result, AS_NAPI_VALUE(jval));
-  return napi_ok;
+  NAPI_RETURN(napi_ok);
 }
 
 napi_status napi_get_undefined(napi_env env, napi_value* result) {
   JERRYX_CREATE(jval, jerry_create_undefined());
   NAPI_ASSIGN(result, AS_NAPI_VALUE(jval));
-  return napi_ok;
+  NAPI_RETURN(napi_ok);
 }
 
 #define DEF_NAPI_COERCE_TO(type, alias)                             \
@@ -161,7 +160,7 @@ napi_status napi_get_undefined(napi_env env, napi_value* result) {
     jerry_value_t jval = AS_JERRY_VALUE(value);                     \
     JERRYX_CREATE(jval_result, jerry_value_to_##alias(jval));       \
     NAPI_ASSIGN(result, AS_NAPI_VALUE(jval_result));                \
-    return napi_ok;                                                 \
+    NAPI_RETURN(napi_ok);                                           \
   }
 
 DEF_NAPI_COERCE_TO(bool, boolean);
@@ -189,10 +188,10 @@ napi_status napi_typeof(napi_env env, napi_value value,
     MAP(JERRY_TYPE_FUNCTION, napi_function);
 #undef MAP
     default:
-      return napi_invalid_arg;
+      NAPI_RETURN(napi_invalid_arg, NULL);
   }
 
-  return napi_ok;
+  NAPI_RETURN(napi_ok);
 }
 
 napi_status napi_instanceof(napi_env env, napi_value object,
@@ -201,14 +200,14 @@ napi_status napi_instanceof(napi_env env, napi_value object,
   jerry_value_t jval_cons = AS_JERRY_VALUE(constructor);
 
   NAPI_ASSIGN(result, jerry_value_instanceof(jval_object, jval_cons));
-  return napi_ok;
+  NAPI_RETURN(napi_ok);
 }
 
 #define DEF_NAPI_VALUE_IS(type)                                              \
   napi_status napi_is_##type(napi_env env, napi_value value, bool* result) { \
     jerry_value_t jval = AS_JERRY_VALUE(value);                              \
     NAPI_ASSIGN(result, jerry_value_is_##type(jval));                        \
-    return napi_ok;                                                          \
+    NAPI_RETURN(napi_ok);                                                    \
   }
 
 DEF_NAPI_VALUE_IS(array);
@@ -222,7 +221,7 @@ napi_status napi_is_error(napi_env env, napi_value value, bool* result) {
    * function `jerry_value_is_error`
    */
   NAPI_ASSIGN(result, jerry_value_has_error_flag(jval));
-  return napi_ok;
+  NAPI_RETURN(napi_ok);
 }
 
 napi_status napi_strict_equals(napi_env env, napi_value lhs, napi_value rhs,
@@ -231,5 +230,5 @@ napi_status napi_strict_equals(napi_env env, napi_value lhs, napi_value rhs,
   jerry_value_t jval_rhs = AS_JERRY_VALUE(rhs);
 
   NAPI_ASSIGN(result, jerry_value_strict_equal(jval_lhs, jval_rhs));
-  return napi_ok;
+  NAPI_RETURN(napi_ok);
 }

--- a/src/napi/node_api_value.c
+++ b/src/napi/node_api_value.c
@@ -19,20 +19,20 @@
 
 napi_status napi_create_array(napi_env env, napi_value* result) {
   JERRYX_CREATE(jval, jerry_create_array(0));
-  *result = AS_NAPI_VALUE(jval);
+  NAPI_ASSIGN(result, AS_NAPI_VALUE(jval));
   return napi_ok;
 }
 
 napi_status napi_create_array_with_length(napi_env env, size_t length,
                                           napi_value* result) {
   JERRYX_CREATE(jval, jerry_create_array(length));
-  *result = AS_NAPI_VALUE(jval);
+  NAPI_ASSIGN(result, AS_NAPI_VALUE(jval));
   return napi_ok;
 }
 
 napi_status napi_create_object(napi_env env, napi_value* result) {
   JERRYX_CREATE(jval, jerry_create_object());
-  *result = AS_NAPI_VALUE(jval);
+  NAPI_ASSIGN(result, AS_NAPI_VALUE(jval));
   return napi_ok;
 }
 
@@ -54,11 +54,11 @@ napi_status napi_create_object(napi_env env, napi_value* result) {
         jerry_string_to_utf8_char_buffer(jval_msg, raw_msg, msg_size);        \
     NAPI_WEAK_ASSERT(napi_invalid_arg, written_size == msg_size);             \
                                                                               \
-    jerry_value_t jval_error = jerry_create_error(jerry_error_type, raw_msg); \
+    JERRYX_CREATE(jval_error, jerry_create_error(jerry_error_type, raw_msg)); \
     jerry_value_clear_error_flag(&jval_error);                                \
                                                                               \
     iotjs_jval_set_property_jval(jval_error, "code", jval_code);              \
-    *result = AS_NAPI_VALUE(jval_error);                                      \
+    NAPI_ASSIGN(result, AS_NAPI_VALUE(jval_error));                           \
                                                                               \
     return napi_ok;                                                           \
   }
@@ -71,9 +71,8 @@ DEF_NAPI_CREATE_ERROR(range_error, JERRY_ERROR_RANGE);
 #define DEF_NAPI_NUMBER_CONVERT_FROM_C_TYPE(type, name)      \
   napi_status napi_create_##name(napi_env env, type value,   \
                                  napi_value* result) {       \
-    jerry_value_t jval = jerry_create_number((double)value); \
-    jerryx_create_handle(jval);                              \
-    *result = AS_NAPI_VALUE(jval);                           \
+    JERRYX_CREATE(jval, jerry_create_number((double)value)); \
+    NAPI_ASSIGN(result, AS_NAPI_VALUE(jval));                \
     return napi_ok;                                          \
   }
 
@@ -87,8 +86,9 @@ DEF_NAPI_NUMBER_CONVERT_FROM_C_TYPE(double, double);
   napi_status napi_get_value_##name(napi_env env, napi_value value, \
                                     type* result) {                 \
     jerry_value_t jval = AS_JERRY_VALUE(value);                     \
+    NAPI_TRY_TYPE(number, jval);                                    \
     double num_val = jerry_get_number_value(jval);                  \
-    *result = num_val;                                              \
+    NAPI_ASSIGN(result, num_val);                                   \
     return napi_ok;                                                 \
   }
 
@@ -100,57 +100,58 @@ DEF_NAPI_NUMBER_CONVERT_FROM_NVALUE(uint32_t, uint32);
 
 napi_status napi_create_string_utf8(napi_env env, const char* str,
                                     size_t length, napi_value* result) {
-  jerry_value_t jval =
-      jerry_create_string_sz_from_utf8((jerry_char_t*)str, length);
-  jerryx_create_handle(jval);
-  *result = AS_NAPI_VALUE(jval);
+  if (length == NAPI_AUTO_LENGTH) {
+    length = strlen(str);
+  }
+  JERRYX_CREATE(jval,
+                jerry_create_string_sz_from_utf8((jerry_char_t*)str, length));
+  NAPI_ASSIGN(result, AS_NAPI_VALUE(jval));
   return napi_ok;
 }
 
 napi_status napi_get_array_length(napi_env env, napi_value value,
                                   uint32_t* result) {
   jerry_value_t jval = AS_JERRY_VALUE(value);
-  *result = jerry_get_array_length(jval);
+  NAPI_ASSIGN(result, jerry_get_array_length(jval));
   return napi_ok;
 }
 
 napi_status napi_get_prototype(napi_env env, napi_value object,
                                napi_value* result) {
   jerry_value_t jval = AS_JERRY_VALUE(object);
-  jerry_value_t jval_proto = jerry_get_prototype(jval);
-  *result = AS_NAPI_VALUE(jval_proto);
+  JERRYX_CREATE(jval_proto, jerry_get_prototype(jval));
+  NAPI_ASSIGN(result, AS_NAPI_VALUE(jval_proto));
   return napi_ok;
 }
 
 napi_status napi_get_value_bool(napi_env env, napi_value value, bool* result) {
   jerry_value_t jval = AS_JERRY_VALUE(value);
-  if (!jerry_value_is_boolean(jval))
-    return napi_boolean_expected;
-  *result = jerry_get_boolean_value(jval);
+  NAPI_TRY_TYPE(boolean, jval);
+  NAPI_ASSIGN(result, jerry_get_boolean_value(jval));
   return napi_ok;
 }
 
 napi_status napi_get_boolean(napi_env env, bool value, napi_value* result) {
   JERRYX_CREATE(jval, jerry_create_boolean(value));
-  *result = AS_NAPI_VALUE(jval);
+  NAPI_ASSIGN(result, AS_NAPI_VALUE(jval));
   return napi_ok;
 }
 
 napi_status napi_get_global(napi_env env, napi_value* result) {
   JERRYX_CREATE(jval, jerry_get_global_object());
-  *result = AS_NAPI_VALUE(jval);
+  NAPI_ASSIGN(result, AS_NAPI_VALUE(jval));
   return napi_ok;
 }
 
 napi_status napi_get_null(napi_env env, napi_value* result) {
   JERRYX_CREATE(jval, jerry_create_null());
-  *result = AS_NAPI_VALUE(jval);
+  NAPI_ASSIGN(result, AS_NAPI_VALUE(jval));
   return napi_ok;
 }
 
 napi_status napi_get_undefined(napi_env env, napi_value* result) {
   JERRYX_CREATE(jval, jerry_create_undefined());
-  *result = AS_NAPI_VALUE(jval);
+  NAPI_ASSIGN(result, AS_NAPI_VALUE(jval));
   return napi_ok;
 }
 
@@ -158,8 +159,8 @@ napi_status napi_get_undefined(napi_env env, napi_value* result) {
   napi_status napi_coerce_to_##type(napi_env env, napi_value value, \
                                     napi_value* result) {           \
     jerry_value_t jval = AS_JERRY_VALUE(value);                     \
-    jerry_value_t jval_result = jerry_value_to_##alias(jval);       \
-    *result = AS_NAPI_VALUE(jval_result);                           \
+    JERRYX_CREATE(jval_result, jerry_value_to_##alias(jval));       \
+    NAPI_ASSIGN(result, AS_NAPI_VALUE(jval_result));                \
     return napi_ok;                                                 \
   }
 
@@ -173,9 +174,9 @@ napi_status napi_typeof(napi_env env, napi_value value,
   jerry_value_t jval = AS_JERRY_VALUE(value);
   jerry_type_t type = jerry_value_get_type(jval);
 
-#define MAP(jerry, napi) \
-  case jerry:            \
-    *result = napi;      \
+#define MAP(jerry, napi)       \
+  case jerry:                  \
+    NAPI_ASSIGN(result, napi); \
     break;
 
   switch (type) {
@@ -199,14 +200,14 @@ napi_status napi_instanceof(napi_env env, napi_value object,
   jerry_value_t jval_object = AS_JERRY_VALUE(object);
   jerry_value_t jval_cons = AS_JERRY_VALUE(constructor);
 
-  *result = jerry_value_instanceof(jval_object, jval_cons);
+  NAPI_ASSIGN(result, jerry_value_instanceof(jval_object, jval_cons));
   return napi_ok;
 }
 
 #define DEF_NAPI_VALUE_IS(type)                                              \
   napi_status napi_is_##type(napi_env env, napi_value value, bool* result) { \
     jerry_value_t jval = AS_JERRY_VALUE(value);                              \
-    *result = jerry_value_is_##type(jval);                                   \
+    NAPI_ASSIGN(result, jerry_value_is_##type(jval));                        \
     return napi_ok;                                                          \
   }
 
@@ -220,7 +221,7 @@ napi_status napi_is_error(napi_env env, napi_value value, bool* result) {
    * TODO: Pick jerrysciprt#ba2e49caaa6703dec7a83fb0b8586a91fac060eb to use
    * function `jerry_value_is_error`
    */
-  *result = jerry_value_has_error_flag(jval);
+  NAPI_ASSIGN(result, jerry_value_has_error_flag(jval));
   return napi_ok;
 }
 
@@ -229,6 +230,6 @@ napi_status napi_strict_equals(napi_env env, napi_value lhs, napi_value rhs,
   jerry_value_t jval_lhs = AS_JERRY_VALUE(lhs);
   jerry_value_t jval_rhs = AS_JERRY_VALUE(rhs);
 
-  *result = jerry_value_strict_equal(jval_lhs, jval_rhs);
+  NAPI_ASSIGN(result, jerry_value_strict_equal(jval_lhs, jval_rhs));
   return napi_ok;
 }

--- a/test/addons-napi/8_passing_wrapped/test.js
+++ b/test/addons-napi/8_passing_wrapped/test.js
@@ -5,7 +5,7 @@
 var assert = require('assert');
 var addon = require(`./build/Release/binding.node`);
 
-let obj1 = addon.createObject(10);
+var obj1 = addon.createObject(10);
 var obj2 = addon.createObject(20);
 var result = addon.add(obj1, obj2);
 assert.strictEqual(result, 30);

--- a/test/addons-napi/test_async/test-async-hooks.js
+++ b/test/addons-napi/test_async/test-async-hooks.js
@@ -5,7 +5,7 @@ var async_hooks = require('async_hooks');
 var test_async = require(`./build/Release/test_async.node`);
 
 var events = [];
-let testId;
+var testId;
 var initAsyncId = async_hooks.executionAsyncId();
 
 async_hooks.createHook({

--- a/test/addons-napi/test_async/test-loop.js
+++ b/test/addons-napi/test_async/test-loop.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 var test_async = require(`./build/Release/test_async.node`);
 var iterations = 500;
 
-let x = 0;
+var x = 0;
 var workDone = common.mustCall((status) => {
   assert.strictEqual(status, 0, 'Work completed successfully');
   if (++x < iterations) {

--- a/test/addons-napi/test_buffer/test.js
+++ b/test/addons-napi/test_buffer/test.js
@@ -12,7 +12,7 @@ global.gc();
 assert.strictEqual(binding.getDeleterCallCount(), 1);
 assert.strictEqual(binding.copyBuffer().toString(), binding.theText);
 
-let buffer = binding.staticBuffer();
+var buffer = binding.staticBuffer();
 assert.strictEqual(binding.bufferHasInstance(buffer), true);
 assert.strictEqual(binding.bufferInfo(buffer), true);
 buffer = null;

--- a/test/addons-napi/test_callback_scope/test-async-hooks.js
+++ b/test/addons-napi/test_callback_scope/test-async-hooks.js
@@ -12,7 +12,7 @@ process.emitWarning = () => {};
 
 var { runInCallbackScope } = require(`./build/Release/binding.node`);
 
-let insideHook = false;
+var insideHook = false;
 async_hooks.createHook({
   before: common.mustCall((id) => {
     assert.strictEqual(id, 1000);

--- a/test/addons-napi/test_constructor/test.js
+++ b/test/addons-napi/test_constructor/test.js
@@ -2,7 +2,7 @@
 
 var assert = require('assert');
 
-// Testing api calls for a varructor that defines properties
+// Testing api calls for a constructor that defines properties
 var TestConstructor = require(`./build/Release/test_constructor.node`);
 var test_object = new TestConstructor();
 

--- a/test/addons-napi/test_constructor/test2.js
+++ b/test/addons-napi/test_constructor/test2.js
@@ -2,7 +2,7 @@
 
 var assert = require('assert');
 
-// Testing api calls for a varructor that defines properties
+// Testing api calls for a constructor that defines properties
 var TestConstructor =
-    require(`./build/Release/test_varructor_name.node`);
+    require(`./build/Release/test_constructor_name.node`);
 assert.strictEqual(TestConstructor.name, 'MyObject');

--- a/test/addons-napi/test_error/test.js
+++ b/test/addons-napi/test_error/test.js
@@ -100,7 +100,7 @@ common.expectsError(
     message: 'TypeError [type error]'
   });
 
-let error = test_error.createError();
+var error = test_error.createError();
 assert.ok(error instanceof Error, 'expected error to be an instance of Error');
 assert.strictEqual(error.message, 'error');
 

--- a/test/addons-napi/test_exception/test.js
+++ b/test/addons-napi/test_exception/test.js
@@ -11,7 +11,7 @@ var theError = new Error('Some error');
 // phase are propagated through require() into JavaScript.
 // https://github.com/nodejs/node/issues/19437
 var test_exception = (function() {
-  let resultingException;
+  var resultingException;
   try {
     require(`./build/Release/test_exception.node`);
   } catch (anException) {
@@ -25,7 +25,7 @@ var test_exception = (function() {
   var throwTheError = () => { throw theError; };
 
   // Test that the native side successfully captures the exception
-  let returnedError = test_exception.returnException(throwTheError);
+  var returnedError = test_exception.returnException(throwTheError);
   assert.strictEqual(theError, returnedError);
 
   // Test that the native side passes the exception through
@@ -50,7 +50,7 @@ var test_exception = (function() {
 
 {
   // Test that no exception appears that was not thrown by us
-  let caughtError;
+  var caughtError;
   try {
     test_exception.allowException(common.mustCall());
   } catch (anError) {
@@ -69,7 +69,7 @@ var test_exception = (function() {
 
 // Make sure that exceptions that occur during finalization are propagated.
 function testFinalize(binding) {
-  let x = test_exception[binding]();
+  var x = test_exception[binding]();
   x = null;
   assert.throws(() => { global.gc(); }, /Error during Finalize/);
 

--- a/test/addons-napi/test_function/test.js
+++ b/test/addons-napi/test_function/test.js
@@ -31,7 +31,7 @@ assert.strictEqual(test_function.TestCall(func4, 1), 2);
 assert.strictEqual(test_function.TestName.name, 'Name');
 assert.strictEqual(test_function.TestNameShort.name, 'Name_');
 
-let tracked_function = test_function.MakeTrackedFunction(common.mustCall());
+var tracked_function = test_function.MakeTrackedFunction(common.mustCall());
 assert(!!tracked_function);
 tracked_function = null;
 global.gc();

--- a/test/addons-napi/test_general/test.js
+++ b/test/addons-napi/test_general/test.js
@@ -59,7 +59,7 @@ assert.strictEqual(test_general.testNapiTypeof(null), 'null');
 
 // Ensure that garbage collecting an object with a wrapped native item results
 // in the finalize callback being called.
-let w = {};
+var w = {};
 test_general.wrap(w);
 w = null;
 global.gc();
@@ -85,7 +85,7 @@ test_general.wrap(y);
 
 // Ensure that removing a wrap and garbage collecting does not fire the
 // finalize callback.
-let z = {};
+var z = {};
 test_general.testFinalizeWrap(z);
 test_general.removeWrap(z);
 z = null;

--- a/test/addons-napi/test_general/testInstanceOf.js
+++ b/test/addons-napi/test_general/testInstanceOf.js
@@ -77,8 +77,8 @@ if (typeof Symbol !== 'undefined' && 'hasInstance' in Symbol &&
   function MySubClass() {}
   MySubClass.prototype = new MyClass();
 
-  let x = new MySubClass();
-  let y = new MySubClass();
+  var x = new MySubClass();
+  var y = new MySubClass();
   x.mark = true;
 
   compareToNative(x, MySubClass);

--- a/test/addons-napi/test_make_callback_recurse/test.js
+++ b/test/addons-napi/test_make_callback_recurse/test.js
@@ -65,7 +65,7 @@ assert.throws(function() {
   results.push(2);
 
   setImmediate(common.mustCall(function() {
-    for (let i = 0; i < results.length; i++) {
+    for (var i = 0; i < results.length; i++) {
       assert.strictEqual(results[i], i,
                          `verifyExecutionOrder(${arg}) results: ${results}`);
     }

--- a/test/addons-napi/test_new_target/test.js
+++ b/test/addons-napi/test_new_target/test.js
@@ -5,7 +5,7 @@ var assert = require('assert');
 var binding = require(`./build/Release/binding.node`);
 
 class Class extends binding.BaseClass {
-  varructor() {
+  constructor() {
     super();
     this.method();
   }

--- a/test/addons-napi/test_threadsafe_function/test.js
+++ b/test/addons-napi/test_threadsafe_function/test.js
@@ -6,7 +6,7 @@ var binding = require(`./build/Release/binding.node`);
 var { fork } = require('child_process');
 var expectedArray = (function(arrayLength) {
   var result = [];
-  for (let index = 0; index < arrayLength; index++) {
+  for (var index = 0; index < arrayLength; index++) {
     result.push(arrayLength - 1 - index);
   }
   return result;
@@ -16,7 +16,7 @@ var expectedArray = (function(arrayLength) {
 // thread-safe function after we have received two values. This causes the
 // process to exit and the environment cleanup handler to be invoked.
 if (process.argv[2] === 'child') {
-  let callCount = 0;
+  var callCount = 0;
   binding.StartThread((value) => {
     callCount++;
     console.log(value);
@@ -60,7 +60,7 @@ function testWithJSMarshaller({
 
 function testUnref(queueSize) {
   return new Promise((resolve, reject) => {
-    let output = '';
+    var output = '';
     var child = fork(__filename, ['child', queueSize], {
       stdio: [process.stdin, 'pipe', process.stderr, 'ipc']
     });
@@ -77,7 +77,7 @@ function testUnref(queueSize) {
 }
 
 new Promise(function testWithoutJSMarshaller(resolve) {
-  let callCount = 0;
+  var callCount = 0;
   binding.StartThreadNoNative(function testCallback() {
     callCount++;
 
@@ -121,7 +121,7 @@ new Promise(function testWithoutJSMarshaller(resolve) {
 .then((result) => assert.deepStrictEqual(result, expectedArray))
 
 // Start the thread in blocking mode, and assert that all values are passed.
-// Quit early, but let the thread finish.
+// Quit early, but var the thread finish.
 .then(() => testWithJSMarshaller({
   threadStarter: 'StartThread',
   maxQueueSize: binding.MAX_QUEUE_SIZE,
@@ -130,7 +130,7 @@ new Promise(function testWithoutJSMarshaller(resolve) {
 .then((result) => assert.deepStrictEqual(result, expectedArray))
 
 // Start the thread in blocking mode with an infinite queue, and assert that all
-// values are passed. Quit early, but let the thread finish.
+// values are passed. Quit early, but var the thread finish.
 .then(() => testWithJSMarshaller({
   threadStarter: 'StartThread',
   maxQueueSize: 0,
@@ -139,7 +139,7 @@ new Promise(function testWithoutJSMarshaller(resolve) {
 .then((result) => assert.deepStrictEqual(result, expectedArray))
 
 // Start the thread in non-blocking mode, and assert that all values are passed.
-// Quit early, but let the thread finish.
+// Quit early, but var the thread finish.
 .then(() => testWithJSMarshaller({
   threadStarter: 'StartThreadNonblocking',
   maxQueueSize: binding.MAX_QUEUE_SIZE,
@@ -148,7 +148,7 @@ new Promise(function testWithoutJSMarshaller(resolve) {
 .then((result) => assert.deepStrictEqual(result, expectedArray))
 
 // Start the thread in blocking mode, and assert that all values are passed.
-// Quit early, but let the thread finish. Launch a secondary thread to test the
+// Quit early, but var the thread finish. Launch a secondary thread to test the
 // reference counter incrementing functionality.
 .then(() => testWithJSMarshaller({
   threadStarter: 'StartThread',
@@ -159,7 +159,7 @@ new Promise(function testWithoutJSMarshaller(resolve) {
 .then((result) => assert.deepStrictEqual(result, expectedArray))
 
 // Start the thread in non-blocking mode, and assert that all values are passed.
-// Quit early, but let the thread finish. Launch a secondary thread to test the
+// Quit early, but var the thread finish. Launch a secondary thread to test the
 // reference counter incrementing functionality.
 .then(() => testWithJSMarshaller({
   threadStarter: 'StartThreadNonblocking',

--- a/test/addons-napi/test_typedarray/test.js
+++ b/test/addons-napi/test_typedarray/test.js
@@ -51,7 +51,7 @@ arrayTypes.forEach((currentType) => {
   assert.ok(theArray instanceof currentType,
             'Type of new array should match that of the template. ' +
             `Expected type: ${currentType.name}, ` +
-            `actual type: ${template.varructor.name}`);
+            `actual type: ${template.constructor.name}`);
   assert.notStrictEqual(theArray, template);
   assert.strictEqual(theArray.buffer, buffer);
 });

--- a/test/napi-testsets.json
+++ b/test/napi-testsets.json
@@ -1,4 +1,13 @@
 {
+  "addons-napi": [
+    { "name": "2_function_arguments/test.js", "skip": false },
+    { "name": "3_callbacks/test.js", "skip": false },
+    { "name": "4_object_factory/test.js", "skip": false },
+    { "name": "5_function_factory/test.js", "skip": false },
+    { "name": "test_general/testGlobals.js", "skip": false },
+    { "name": "test_general/testInstanceOf.js", "skip": false },
+    { "name": "test_general/testNapiStatus.js", "skip": false }
+  ],
   "napi": [
     { "name": "napi.test.js" }
   ]

--- a/tools/pull-napi.sh
+++ b/tools/pull-napi.sh
@@ -86,8 +86,10 @@ for file in test/addons-napi/**/*.js; do
   declare -a exps=(
     # `const common = require('../../common');` => ``
     "s/const common = require.'\.\.\/\.\.\/common'.;//"
-    # `const` => `var`
-    "s/const/var/"
+    # `const ` => `var `
+    "s/const /var /"
+    # `let ` => `var `
+    "s/let /var /"
     # `${common.buildType}` => `Release`
     's/\$\{common\.buildType\}/Release/'
     # `./build/Release/binding` => `./build/Release/binding.node`

--- a/tools/testrunner.py
+++ b/tools/testrunner.py
@@ -272,6 +272,9 @@ class TestRunner(object):
     def skip_test(self, test):
         skip_list = test.get("skip", [])
 
+        if skip_list is False:
+            return False
+
         # Skip by the `skip` attribute in testsets.json file.
         for i in ["all", Platform().os(), self.stability]:
             if i in skip_list:


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added

Issues fixed in this PR:

1. In most N-API functions, there is an in-out pointer parameter to retrieve return values, yet this pointer could be NULL anyway - it has to be ensured no value were unexpectedly written to NULL pointer.
2.  If any non-napi-ok status code is returned in N-API functions, there should be an error code and error message temporarily stored in napi-env and can be fetched by `napi_get_last_error_info` until next napi function called.