### PR TITLE
napi: null terminator on copying string value

### DIFF
--- a/src/napi/node_api_function.c
+++ b/src/napi/node_api_function.c
@@ -60,13 +60,11 @@ static jerry_value_t iotjs_napi_function_handler(
   }
 
   // TODO: check if nvalue_ret is escaped
-  if (nvalue_ret == NULL) {
-    jval_ret = jerry_create_undefined();
-  } else {
-    /** jval returned from N-API functions is scoped */
-    jval_ret = AS_JERRY_VALUE(nvalue_ret);
-  }
-
+  /**
+   * Do not turn NULL pointer into undefined since number value `0` in
+   * jerryscript also represented by NULL
+   */
+  jval_ret = AS_JERRY_VALUE(nvalue_ret);
 
 cleanup:
   jerryx_remove_handle(scope, jval_ret, &jval_ret);

--- a/src/napi/node_api_value.c
+++ b/src/napi/node_api_value.c
@@ -202,8 +202,8 @@ napi_status napi_get_value_string_utf8(napi_env env, napi_value value,
   jerry_value_t jval = AS_JERRY_VALUE(value);
   NAPI_TRY_TYPE(string, jval);
 
+  size_t str_size = jerry_get_utf8_string_size(jval);
   if (buf == NULL) {
-    size_t str_size = jerry_get_utf8_string_size(jval);
     /** null terminator is excluded */
     NAPI_ASSIGN(result, str_size);
     NAPI_RETURN(napi_ok);
@@ -211,8 +211,13 @@ napi_status napi_get_value_string_utf8(napi_env env, napi_value value,
 
   jerry_size_t written_size =
       jerry_string_to_utf8_char_buffer(jval, (jerry_char_t*)buf, bufsize);
+  NAPI_WEAK_ASSERT(napi_generic_failure,
+                   str_size == 0 || (bufsize > 0 && written_size != 0),
+                   "Insufficient buffer not supported yet.");
   /** expects one more byte to write null terminator  */
-  buf[written_size] = '\0';
+  if (bufsize > written_size) {
+    buf[written_size] = '\0';
+  }
   NAPI_ASSIGN(result, written_size);
   NAPI_RETURN(napi_ok);
 }

--- a/src/napi/node_api_value.c
+++ b/src/napi/node_api_value.c
@@ -204,12 +204,15 @@ napi_status napi_get_value_string_utf8(napi_env env, napi_value value,
 
   if (buf == NULL) {
     size_t str_size = jerry_get_utf8_string_size(jval);
+    /** null terminator is excluded */
     NAPI_ASSIGN(result, str_size);
     NAPI_RETURN(napi_ok);
   }
 
   jerry_size_t written_size =
       jerry_string_to_utf8_char_buffer(jval, (jerry_char_t*)buf, bufsize);
+  /** expects one more byte to write null terminator  */
+  buf[written_size] = '\0';
   NAPI_ASSIGN(result, written_size);
   NAPI_RETURN(napi_ok);
 }

--- a/src/napi/node_api_value.c
+++ b/src/napi/node_api_value.c
@@ -204,7 +204,7 @@ napi_status napi_get_value_string_utf8(napi_env env, napi_value value,
 
   size_t str_size = jerry_get_utf8_string_size(jval);
   if (buf == NULL) {
-    /** null terminator is excluded */
+    /* null terminator is excluded */
     NAPI_ASSIGN(result, str_size);
     NAPI_RETURN(napi_ok);
   }
@@ -214,7 +214,7 @@ napi_status napi_get_value_string_utf8(napi_env env, napi_value value,
   NAPI_WEAK_ASSERT(napi_generic_failure,
                    str_size == 0 || (bufsize > 0 && written_size != 0),
                    "Insufficient buffer not supported yet.");
-  /** expects one more byte to write null terminator  */
+  /* expects one more byte to write null terminator  */
   if (bufsize > written_size) {
     buf[written_size] = '\0';
   }

--- a/test/napi-testsets.json
+++ b/test/napi-testsets.json
@@ -55,6 +55,7 @@
     { "name": "test_uv_loop/test.js", "skip": ["all"], "reason": "uv api not implemented" }
   ],
   "napi": [
-    { "name": "napi.test.js" }
+    { "name": "napi_string.test.js", "skip": false },
+    { "name": "napi.test.js", "skip": false }
   ]
 }

--- a/test/napi/binding.gyp
+++ b/test/napi/binding.gyp
@@ -3,6 +3,10 @@
     {
       "target_name": "napi_test",
       "sources": [ "napi.test.c" ]
+    },
+    {
+      "target_name": "napi_string",
+      "sources": [ "napi_string.c" ]
     }
   ]
 }

--- a/test/napi/common.h
+++ b/test/napi/common.h
@@ -56,8 +56,9 @@
 #define DECLARE_NAPI_GETTER(name, func) \
   { (name), 0, 0, (func), 0, 0, napi_default, 0 }
 
-#define set_named_method(env, target, prop_name, handler)            \
+#define SET_NAMED_METHOD(env, target, prop_name, handler)            \
   do {                                                               \
+    napi_status status;                                              \
     napi_value fn;                                                   \
     status = napi_create_function(env, NULL, 0, handler, NULL, &fn); \
     if (status != napi_ok)                                           \

--- a/test/napi/common.h
+++ b/test/napi/common.h
@@ -1,0 +1,72 @@
+// Empty value so that macros here are able to return NULL or void
+#define NAPI_RETVAL_NOTHING  // Intentionally blank #define
+
+#define GET_AND_THROW_LAST_ERROR(env)                                    \
+  do {                                                                   \
+    const napi_extended_error_info *error_info;                          \
+    napi_get_last_error_info((env), &error_info);                        \
+    bool is_pending;                                                     \
+    napi_is_exception_pending((env), &is_pending);                       \
+    /* If an exception is already pending, don't rethrow it */           \
+    if (!is_pending) {                                                   \
+      const char* error_message = error_info->error_message != NULL ?    \
+        error_info->error_message :                                      \
+        "empty error message";                                           \
+      napi_throw_error((env), NULL, error_message);                      \
+    }                                                                    \
+  } while (0)
+
+#define NAPI_ASSERT_BASE(env, assertion, message, ret_val)               \
+  do {                                                                   \
+    if (!(assertion)) {                                                  \
+      napi_throw_error(                                                  \
+          (env),                                                         \
+        NULL,                                                            \
+          "assertion (" #assertion ") failed: " message);                \
+      return ret_val;                                                    \
+    }                                                                    \
+  } while (0)
+
+// Returns NULL on failed assertion.
+// This is meant to be used inside napi_callback methods.
+#define NAPI_ASSERT(env, assertion, message)                             \
+  NAPI_ASSERT_BASE(env, assertion, message, NULL)
+
+// Returns empty on failed assertion.
+// This is meant to be used inside functions with void return type.
+#define NAPI_ASSERT_RETURN_VOID(env, assertion, message)                 \
+  NAPI_ASSERT_BASE(env, assertion, message, NAPI_RETVAL_NOTHING)
+
+#define NAPI_CALL_BASE(env, the_call, ret_val)                           \
+  do {                                                                   \
+    if ((the_call) != napi_ok) {                                         \
+      GET_AND_THROW_LAST_ERROR((env));                                   \
+      return ret_val;                                                    \
+    }                                                                    \
+  } while (0)
+
+// Returns NULL if the_call doesn't return napi_ok.
+#define NAPI_CALL(env, the_call)                                         \
+  NAPI_CALL_BASE(env, the_call, NULL)
+
+// Returns empty if the_call doesn't return napi_ok.
+#define NAPI_CALL_RETURN_VOID(env, the_call)                             \
+  NAPI_CALL_BASE(env, the_call, NAPI_RETVAL_NOTHING)
+
+#define DECLARE_NAPI_PROPERTY(name, func)                                \
+  { (name), 0, (func), 0, 0, 0, napi_default, 0 }
+
+#define DECLARE_NAPI_GETTER(name, func)                                  \
+  { (name), 0, 0, (func), 0, 0, napi_default, 0 }
+
+#define set_named_method(env, target, prop_name, handler)            \
+  do {                                                               \
+    napi_value fn;                                                   \
+    status = napi_create_function(env, NULL, 0, handler, NULL, &fn); \
+    if (status != napi_ok)                                           \
+      return NULL;                                                   \
+                                                                     \
+    status = napi_set_named_property(env, target, prop_name, fn);    \
+    if (status != napi_ok)                                           \
+      return NULL;                                                   \
+  } while (0);

--- a/test/napi/common.h
+++ b/test/napi/common.h
@@ -1,62 +1,59 @@
 // Empty value so that macros here are able to return NULL or void
-#define NAPI_RETVAL_NOTHING  // Intentionally blank #define
+#define NAPI_RETVAL_NOTHING // Intentionally blank #define
 
-#define GET_AND_THROW_LAST_ERROR(env)                                    \
-  do {                                                                   \
-    const napi_extended_error_info *error_info;                          \
-    napi_get_last_error_info((env), &error_info);                        \
-    bool is_pending;                                                     \
-    napi_is_exception_pending((env), &is_pending);                       \
-    /* If an exception is already pending, don't rethrow it */           \
-    if (!is_pending) {                                                   \
-      const char* error_message = error_info->error_message != NULL ?    \
-        error_info->error_message :                                      \
-        "empty error message";                                           \
-      napi_throw_error((env), NULL, error_message);                      \
-    }                                                                    \
+#define GET_AND_THROW_LAST_ERROR(env)                               \
+  do {                                                              \
+    const napi_extended_error_info* error_info;                     \
+    napi_get_last_error_info((env), &error_info);                   \
+    bool is_pending;                                                \
+    napi_is_exception_pending((env), &is_pending);                  \
+    /* If an exception is already pending, don't rethrow it */      \
+    if (!is_pending) {                                              \
+      const char* error_message = error_info->error_message != NULL \
+                                      ? error_info->error_message   \
+                                      : "empty error message";      \
+      napi_throw_error((env), NULL, error_message);                 \
+    }                                                               \
   } while (0)
 
-#define NAPI_ASSERT_BASE(env, assertion, message, ret_val)               \
-  do {                                                                   \
-    if (!(assertion)) {                                                  \
-      napi_throw_error(                                                  \
-          (env),                                                         \
-        NULL,                                                            \
-          "assertion (" #assertion ") failed: " message);                \
-      return ret_val;                                                    \
-    }                                                                    \
+#define NAPI_ASSERT_BASE(env, assertion, message, ret_val)             \
+  do {                                                                 \
+    if (!(assertion)) {                                                \
+      napi_throw_error((env), NULL,                                    \
+                       "assertion (" #assertion ") failed: " message); \
+      return ret_val;                                                  \
+    }                                                                  \
   } while (0)
 
 // Returns NULL on failed assertion.
 // This is meant to be used inside napi_callback methods.
-#define NAPI_ASSERT(env, assertion, message)                             \
+#define NAPI_ASSERT(env, assertion, message) \
   NAPI_ASSERT_BASE(env, assertion, message, NULL)
 
 // Returns empty on failed assertion.
 // This is meant to be used inside functions with void return type.
-#define NAPI_ASSERT_RETURN_VOID(env, assertion, message)                 \
+#define NAPI_ASSERT_RETURN_VOID(env, assertion, message) \
   NAPI_ASSERT_BASE(env, assertion, message, NAPI_RETVAL_NOTHING)
 
-#define NAPI_CALL_BASE(env, the_call, ret_val)                           \
-  do {                                                                   \
-    if ((the_call) != napi_ok) {                                         \
-      GET_AND_THROW_LAST_ERROR((env));                                   \
-      return ret_val;                                                    \
-    }                                                                    \
+#define NAPI_CALL_BASE(env, the_call, ret_val) \
+  do {                                         \
+    if ((the_call) != napi_ok) {               \
+      GET_AND_THROW_LAST_ERROR((env));         \
+      return ret_val;                          \
+    }                                          \
   } while (0)
 
 // Returns NULL if the_call doesn't return napi_ok.
-#define NAPI_CALL(env, the_call)                                         \
-  NAPI_CALL_BASE(env, the_call, NULL)
+#define NAPI_CALL(env, the_call) NAPI_CALL_BASE(env, the_call, NULL)
 
 // Returns empty if the_call doesn't return napi_ok.
-#define NAPI_CALL_RETURN_VOID(env, the_call)                             \
+#define NAPI_CALL_RETURN_VOID(env, the_call) \
   NAPI_CALL_BASE(env, the_call, NAPI_RETVAL_NOTHING)
 
-#define DECLARE_NAPI_PROPERTY(name, func)                                \
+#define DECLARE_NAPI_PROPERTY(name, func) \
   { (name), 0, (func), 0, 0, 0, napi_default, 0 }
 
-#define DECLARE_NAPI_GETTER(name, func)                                  \
+#define DECLARE_NAPI_GETTER(name, func) \
   { (name), 0, 0, (func), 0, 0, napi_default, 0 }
 
 #define set_named_method(env, target, prop_name, handler)            \

--- a/test/napi/napi.test.c
+++ b/test/napi/napi.test.c
@@ -1,6 +1,7 @@
 #include <node_api.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include "common.h"
 
 napi_value SayHello(napi_env env, napi_callback_info info) {
   napi_status status;
@@ -77,18 +78,6 @@ napi_value Instanceof(napi_env env, napi_callback_info info) {
 
 napi_value Init(napi_env env, napi_value exports) {
   napi_status status;
-
-#define set_named_method(env, target, prop_name, handler)            \
-  do {                                                               \
-    napi_value fn;                                                   \
-    status = napi_create_function(env, NULL, 0, handler, NULL, &fn); \
-    if (status != napi_ok)                                           \
-      return NULL;                                                   \
-                                                                     \
-    status = napi_set_named_property(env, target, prop_name, fn);    \
-    if (status != napi_ok)                                           \
-      return NULL;                                                   \
-  } while (0);
 
   set_named_method(env, exports, "sayHello", SayHello);
   set_named_method(env, exports, "sayError", SayError);

--- a/test/napi/napi.test.c
+++ b/test/napi/napi.test.c
@@ -79,10 +79,10 @@ napi_value Instanceof(napi_env env, napi_callback_info info) {
 napi_value Init(napi_env env, napi_value exports) {
   napi_status status;
 
-  set_named_method(env, exports, "sayHello", SayHello);
-  set_named_method(env, exports, "sayError", SayError);
-  set_named_method(env, exports, "strictEquals", StrictEquals);
-  set_named_method(env, exports, "instanceof", Instanceof);
+  SET_NAMED_METHOD(env, exports, "sayHello", SayHello);
+  SET_NAMED_METHOD(env, exports, "sayError", SayError);
+  SET_NAMED_METHOD(env, exports, "strictEquals", StrictEquals);
+  SET_NAMED_METHOD(env, exports, "instanceof", Instanceof);
 
   napi_value id;
   status = napi_create_int32(env, 321, &id);

--- a/test/napi/napi.test.c
+++ b/test/napi/napi.test.c
@@ -4,94 +4,63 @@
 #include "common.h"
 
 napi_value SayHello(napi_env env, napi_callback_info info) {
-  napi_status status;
-
   size_t argc = 0;
   // test if `napi_get_cb_info` tolerants NULL pointers.
-  status = napi_get_cb_info(env, info, &argc, NULL, NULL, NULL);
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, NULL, NULL, NULL));
 
   napi_value str;
-  status = napi_create_string_utf8(env, "Hello", 5, &str);
-  if (status != napi_ok)
-    return NULL;
+  NAPI_CALL(env, napi_create_string_utf8(env, "Hello", 5, &str));
 
   return str;
 }
 
 napi_value SayError(napi_env env, napi_callback_info info) {
-  napi_status status;
-
-  status = napi_throw_error(env, "foo", "bar");
-  if (status != napi_ok)
-    return NULL;
+  NAPI_CALL(env, napi_throw_error(env, "foo", "bar"));
 
   return NULL;
 }
 
 napi_value StrictEquals(napi_env env, napi_callback_info info) {
-  napi_status status;
-
   size_t argc = 2;
   napi_value argv[2];
   napi_value thisArg;
   void* data;
-  status = napi_get_cb_info(env, info, &argc, argv, &thisArg, &data);
-  if (status != napi_ok)
-    return NULL;
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, argv, &thisArg, &data));
 
   bool result = false;
-  status = napi_strict_equals(env, argv[0], argv[1], &result);
-  if (status != napi_ok)
-    return NULL;
+  NAPI_CALL(env, napi_strict_equals(env, argv[0], argv[1], &result));
 
   napi_value ret;
-  status = napi_get_boolean(env, result, &ret);
-  if (status != napi_ok)
-    return NULL;
+  NAPI_CALL(env, napi_get_boolean(env, result, &ret));
 
   return ret;
 }
 
 napi_value Instanceof(napi_env env, napi_callback_info info) {
-  napi_status status;
-
   size_t argc = 2;
   napi_value argv[2];
   napi_value thisArg;
   void* data;
-  status = napi_get_cb_info(env, info, &argc, argv, &thisArg, &data);
-  if (status != napi_ok)
-    return NULL;
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, argv, &thisArg, &data));
 
   bool result = false;
-  status = napi_instanceof(env, argv[0], argv[1], &result);
-  if (status != napi_ok)
-    return NULL;
+  NAPI_CALL(env, napi_instanceof(env, argv[0], argv[1], &result));
 
   napi_value ret;
-  status = napi_get_boolean(env, result, &ret);
-  if (status != napi_ok)
-    return NULL;
+  NAPI_CALL(env, napi_get_boolean(env, result, &ret));
 
   return ret;
 }
 
 napi_value Init(napi_env env, napi_value exports) {
-  napi_status status;
-
   SET_NAMED_METHOD(env, exports, "sayHello", SayHello);
   SET_NAMED_METHOD(env, exports, "sayError", SayError);
   SET_NAMED_METHOD(env, exports, "strictEquals", StrictEquals);
   SET_NAMED_METHOD(env, exports, "instanceof", Instanceof);
 
   napi_value id;
-  status = napi_create_int32(env, 321, &id);
-  if (status != napi_ok)
-    return NULL;
-
-  status = napi_set_named_property(env, exports, "id", id);
-  if (status != napi_ok)
-    return NULL;
+  NAPI_CALL(env, napi_create_int32(env, 321, &id));
+  NAPI_CALL(env, napi_set_named_property(env, exports, "id", id));
 
   return exports;
 }

--- a/test/napi/napi_string.c
+++ b/test/napi/napi_string.c
@@ -81,9 +81,9 @@ static napi_value Utf8Length(napi_env env, napi_callback_info info) {
 napi_value Init(napi_env env, napi_value exports) {
   napi_status status;
 
-  set_named_method(env, exports, "TestUtf8", TestUtf8);
-  set_named_method(env, exports, "TestUtf8Insufficient", TestUtf8Insufficient);
-  set_named_method(env, exports, "Utf8Length", Utf8Length);
+  SET_NAMED_METHOD(env, exports, "TestUtf8", TestUtf8);
+  SET_NAMED_METHOD(env, exports, "TestUtf8Insufficient", TestUtf8Insufficient);
+  SET_NAMED_METHOD(env, exports, "Utf8Length", Utf8Length);
 
   return exports;
 }

--- a/test/napi/napi_string.c
+++ b/test/napi/napi_string.c
@@ -1,0 +1,91 @@
+#include <node_api.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "common.h"
+
+static napi_value TestUtf8(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value args[1];
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+
+  NAPI_ASSERT(env, argc >= 1, "Wrong number of arguments");
+
+  napi_valuetype valuetype;
+  NAPI_CALL(env, napi_typeof(env, args[0], &valuetype));
+
+  NAPI_ASSERT(env, valuetype == napi_string,
+      "Wrong type of argment. Expects a string.");
+
+  char buffer[128];
+  size_t buffer_size = 128;
+  size_t copied;
+
+  NAPI_CALL(env,
+      napi_get_value_string_utf8(env, args[0], buffer, buffer_size, &copied));
+
+  napi_value output;
+  NAPI_CALL(env, napi_create_string_utf8(env, buffer, copied, &output));
+
+  return output;
+}
+
+
+static napi_value TestUtf8Insufficient(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value args[1];
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+
+  NAPI_ASSERT(env, argc >= 1, "Wrong number of arguments");
+
+  napi_valuetype valuetype;
+  NAPI_CALL(env, napi_typeof(env, args[0], &valuetype));
+
+  NAPI_ASSERT(env, valuetype == napi_string,
+      "Wrong type of argment. Expects a string.");
+
+  char buffer[4];
+  size_t buffer_size = 4;
+  size_t copied;
+
+  NAPI_CALL(env,
+      napi_get_value_string_utf8(env, args[0], buffer, buffer_size, &copied));
+
+  napi_value output;
+  NAPI_CALL(env, napi_create_string_utf8(env, buffer, copied, &output));
+
+  return output;
+}
+
+static napi_value Utf8Length(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value args[1];
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+
+  NAPI_ASSERT(env, argc >= 1, "Wrong number of arguments");
+
+  napi_valuetype valuetype;
+  NAPI_CALL(env, napi_typeof(env, args[0], &valuetype));
+
+  NAPI_ASSERT(env, valuetype == napi_string,
+      "Wrong type of argment. Expects a string.");
+
+  size_t length;
+  NAPI_CALL(env, napi_get_value_string_utf8(env, args[0], NULL, 0, &length));
+
+  napi_value output;
+  NAPI_CALL(env, napi_create_uint32(env, (uint32_t)length, &output));
+
+  return output;
+}
+
+napi_value Init(napi_env env, napi_value exports) {
+  napi_status status;
+
+  set_named_method(env, exports, "TestUtf8", TestUtf8);
+  set_named_method(env, exports, "TestUtf8Insufficient", TestUtf8Insufficient);
+  set_named_method(env, exports, "Utf8Length", Utf8Length);
+
+  return exports;
+}
+
+NAPI_MODULE(napi_test, Init);

--- a/test/napi/napi_string.c
+++ b/test/napi/napi_string.c
@@ -79,8 +79,6 @@ static napi_value Utf8Length(napi_env env, napi_callback_info info) {
 }
 
 napi_value Init(napi_env env, napi_value exports) {
-  napi_status status;
-
   SET_NAMED_METHOD(env, exports, "TestUtf8", TestUtf8);
   SET_NAMED_METHOD(env, exports, "TestUtf8Insufficient", TestUtf8Insufficient);
   SET_NAMED_METHOD(env, exports, "Utf8Length", Utf8Length);

--- a/test/napi/napi_string.c
+++ b/test/napi/napi_string.c
@@ -14,14 +14,14 @@ static napi_value TestUtf8(napi_env env, napi_callback_info info) {
   NAPI_CALL(env, napi_typeof(env, args[0], &valuetype));
 
   NAPI_ASSERT(env, valuetype == napi_string,
-      "Wrong type of argment. Expects a string.");
+              "Wrong type of argment. Expects a string.");
 
   char buffer[128];
   size_t buffer_size = 128;
   size_t copied;
 
-  NAPI_CALL(env,
-      napi_get_value_string_utf8(env, args[0], buffer, buffer_size, &copied));
+  NAPI_CALL(env, napi_get_value_string_utf8(env, args[0], buffer, buffer_size,
+                                            &copied));
 
   napi_value output;
   NAPI_CALL(env, napi_create_string_utf8(env, buffer, copied, &output));
@@ -41,14 +41,14 @@ static napi_value TestUtf8Insufficient(napi_env env, napi_callback_info info) {
   NAPI_CALL(env, napi_typeof(env, args[0], &valuetype));
 
   NAPI_ASSERT(env, valuetype == napi_string,
-      "Wrong type of argment. Expects a string.");
+              "Wrong type of argment. Expects a string.");
 
   char buffer[4];
   size_t buffer_size = 4;
   size_t copied;
 
-  NAPI_CALL(env,
-      napi_get_value_string_utf8(env, args[0], buffer, buffer_size, &copied));
+  NAPI_CALL(env, napi_get_value_string_utf8(env, args[0], buffer, buffer_size,
+                                            &copied));
 
   napi_value output;
   NAPI_CALL(env, napi_create_string_utf8(env, buffer, copied, &output));
@@ -67,7 +67,7 @@ static napi_value Utf8Length(napi_env env, napi_callback_info info) {
   NAPI_CALL(env, napi_typeof(env, args[0], &valuetype));
 
   NAPI_ASSERT(env, valuetype == napi_string,
-      "Wrong type of argment. Expects a string.");
+              "Wrong type of argment. Expects a string.");
 
   size_t length;
   NAPI_CALL(env, napi_get_value_string_utf8(env, args[0], NULL, 0, &length));

--- a/test/napi/napi_string.test.js
+++ b/test/napi/napi_string.test.js
@@ -1,0 +1,28 @@
+var assert = require('assert');
+var test = require('./build/Release/napi_string.node');
+
+var empty = '';
+assert.strictEqual(test.TestUtf8(empty), empty);
+assert.strictEqual(test.Utf8Length(empty), 0);
+
+var str1 = 'hello world';
+assert.strictEqual(test.TestUtf8(str1), str1);
+assert.strictEqual(test.Utf8Length(str1), 11);
+
+var str2 = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+assert.strictEqual(test.TestUtf8(str2), str2);
+assert.strictEqual(test.Utf8Length(str2), 62);
+
+var str3 = '?!@#$%^&*()_+-=[]{}/.,<>\'"\\';
+assert.strictEqual(test.TestUtf8(str3), str3);
+assert.strictEqual(test.Utf8Length(str3), 27);
+
+var str4 = '¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿';
+assert.strictEqual(test.TestUtf8(str4), str4);
+assert.strictEqual(test.Utf8Length(str4), 62);
+
+var str5 = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþ';
+assert.strictEqual(test.TestUtf8(str5), str5);
+assert.strictEqual(test.Utf8Length(str5), 126);
+
+// TODO: jerry-script doesn't support copy string value to insufficient buf


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added

Issues fixed in this PR:

- no null terminator added on end of string on copying string value
- returning number value `0` on N-API function would be transformed to `undefined`: now no tranformation is performed