### PR TITLE
console: fix print object for single parameter

### DIFF
--- a/src/js/console.js
+++ b/src/js/console.js
@@ -48,7 +48,7 @@ function stderr(text) {
 Console.prototype.log =
 Console.prototype.debug =
 Console.prototype.info = function() {
-    stdout(util.format.apply(this, arguments) + '\n');
+  stdout(util.format.apply(this, arguments) + '\n');
 };
 
 Console.prototype.warn =

--- a/src/js/console.js
+++ b/src/js/console.js
@@ -58,9 +58,9 @@ Console.prototype.info = function() {
 Console.prototype.warn =
 Console.prototype.error = function() {
   if (arguments.length === 1) {
-    stdout(util.formatValue(arguments[0]) + '\n');
+    stderr(util.formatValue(arguments[0]) + '\n');
   } else {
-    stdout(util.format.apply(this, arguments) + '\n');
+    stderr(util.format.apply(this, arguments) + '\n');
   }
 };
 

--- a/src/js/console.js
+++ b/src/js/console.js
@@ -48,12 +48,20 @@ function stderr(text) {
 Console.prototype.log =
 Console.prototype.debug =
 Console.prototype.info = function() {
-  stdout(util.format.apply(this, arguments) + '\n');
+  if (arguments.length === 1) {
+    stdout(util.formatValue(arguments[0]) + '\n');
+  } else {
+    stdout(util.format.apply(this, arguments) + '\n');
+  }
 };
 
 Console.prototype.warn =
 Console.prototype.error = function() {
-  stderr(util.format.apply(this, arguments) + '\n');
+  if (arguments.length === 1) {
+    stdout(util.formatValue(arguments[0]) + '\n');
+  } else {
+    stdout(util.format.apply(this, arguments) + '\n');
+  }
 };
 
 Console.prototype.time = function(label) {

--- a/src/js/console.js
+++ b/src/js/console.js
@@ -48,20 +48,12 @@ function stderr(text) {
 Console.prototype.log =
 Console.prototype.debug =
 Console.prototype.info = function() {
-  if (arguments.length === 1) {
-    stdout(arguments[0] + '\n');
-  } else {
     stdout(util.format.apply(this, arguments) + '\n');
-  }
 };
 
 Console.prototype.warn =
 Console.prototype.error = function() {
-  if (arguments.length === 1) {
-    stderr(arguments[0] + '\n');
-  } else {
-    stderr(util.format.apply(this, arguments) + '\n');
-  }
+  stderr(util.format.apply(this, arguments) + '\n');
 };
 
 Console.prototype.time = function(label) {

--- a/src/js/console.js
+++ b/src/js/console.js
@@ -49,18 +49,18 @@ Console.prototype.log =
 Console.prototype.debug =
 Console.prototype.info = function() {
   if (arguments.length === 1) {
-    stdout(util.formatValue(arguments[0]) + '\n');
+    stdout(`${util.formatValue(arguments[0])}\n`);
   } else {
-    stdout(util.format.apply(this, arguments) + '\n');
+    stdout(`${util.format.apply(this, arguments)}\n`);
   }
 };
 
 Console.prototype.warn =
 Console.prototype.error = function() {
   if (arguments.length === 1) {
-    stderr(util.formatValue(arguments[0]) + '\n');
+    stderr(`${util.formatValue(arguments[0])}\n`);
   } else {
-    stderr(util.format.apply(this, arguments) + '\n');
+    stderr(`${util.format.apply(this, arguments)}\n`);
   }
 };
 
@@ -73,7 +73,7 @@ Console.prototype.timeEnd = function(label) {
 
   var time = this._times[label];
   if (time === undefined) {
-    process.emitWarning('No such label ' + label + ' for console.timeEnd()');
+    process.emitWarning(`No such label ${label} for console.timeEnd()`);
     return;
   }
 

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -263,4 +263,5 @@ exports.errnoException = errnoException;
 exports.stringToNumber = stringToNumber;
 exports.inherits = inherits;
 exports.format = format;
+exports.formatValue = formatValue;
 exports.deprecate = deprecate;


### PR DESCRIPTION
Format console.log's param using util.formatValue when the function has only one param. The performance is the same as before:
```
console/common.js n=128: 6,353.840618673461   #before
console/common.js n=128: 6,344.13890531784     #after
```


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
