### PR TITLE
dbus: expose the internal member privately

### DIFF
--- a/src/js/dbus.js
+++ b/src/js/dbus.js
@@ -265,6 +265,7 @@ Bus.prototype.getService = function(name) {
  * @param {String} name
  */
 function Service(bus, name) {
+  this._bus = bus;
   this._dbus = bus.dbus;
   this._dbus.setMessageHandler(this.handleMessage.bind(this));
   this._dbus.requestName(name);

--- a/src/js/dbus.js
+++ b/src/js/dbus.js
@@ -265,7 +265,11 @@ Bus.prototype.getService = function(name) {
  * @param {String} name
  */
 function Service(bus, name) {
-  this._bus = bus;
+  Object.defineProperty(this, '_bus', {
+    value: bus,
+    writable: false,
+    enumerable: false,
+  });
   this._dbus = bus.dbus;
   this._dbus.setMessageHandler(this.handleMessage.bind(this));
   this._dbus.requestName(name);


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added

Exposes the low-level member `_bus` for signal handler usage.