### PR TITLE
fix: cipher.update shall use underlying buffer directly

### DIFF
--- a/src/js/crypto.js
+++ b/src/js/crypto.js
@@ -12,8 +12,12 @@ function Hash(algorithm) {
 }
 
 Hash.prototype.update = function(buf, inputEncoding) {
-  if (Buffer.isBuffer(buf) && inputEncoding) {
-    buf = buf.toString(inputEncoding);
+  if (typeof buf !== 'string' && !Buffer.isBuffer(buf)) {
+    throw new TypeError(
+      'Expect buffer or string on first argument of cipher.update.');
+  }
+  if (typeof buf === 'string') {
+    buf = Buffer.from(buf, inputEncoding);
   }
   this._handle.update(buf);
   return this;

--- a/src/modules/iotjs_module_crypto_hash.c
+++ b/src/modules/iotjs_module_crypto_hash.c
@@ -55,11 +55,11 @@ JS_FUNCTION(HashUpdate) {
   JS_DECLARE_THIS_PTR(crypto_hash, hash);
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_crypto_hash_t, hash);
 
-  jerry_value_t value = jargv[0];
-  jerry_size_t size = jerry_get_string_size(value);
-  jerry_char_t buf[size];
-  jerry_string_to_char_buffer(value, buf, size);
-  mbedtls_md_update(&_this->ctx, (const unsigned char*)buf, size);
+  jerry_value_t jval = jargv[0];
+  iotjs_bufferwrap_t* buf_wrap = iotjs_bufferwrap_from_jbuffer(jval);
+  size_t size = iotjs_bufferwrap_length(buf_wrap);
+  char* buf = iotjs_bufferwrap_buffer(buf_wrap);
+  mbedtls_md_update(&_this->ctx, (unsigned char*)buf, size);
   return jerry_create_null();
 }
 

--- a/test/run_pass/test_crypto_hash.js
+++ b/test/run_pass/test_crypto_hash.js
@@ -1,9 +1,12 @@
+'use strict'
 var assert = require('assert');
+var fs = require('fs');
+var path = require('path');
 var crypto = require('crypto');
 
 function test_hash(algorithm, input, output) {
   var hash = crypto.createHash(algorithm);
-  assert.equal(hash.update(input).digest('hex'), output);
+  assert.strictEqual(hash.update(input).digest('hex'), output);
 }
 
 test_hash('md5', 'foobar', '3858f62230ac3c915f300c664312c63f');
@@ -12,3 +15,19 @@ test_hash('sha256', 'foobar',
           'c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2');
 test_hash('sha256', '中文',
           '72726d8818f693066ceb69afa364218b692e62ea92b385782363780f47529c21');
+
+function test_update(algorithm, file, expect) {
+  // forced to split buffers
+  var stream = fs.createReadStream(file, { highWaterMark: 128 });
+  var cipher = crypto.createHash(algorithm);
+  stream.on('data', (buf) => cipher.update(buf));
+  stream.on('end', () => {
+    var hash = cipher.digest('hex');
+    assert.strictEqual(hash, expect);
+  });
+}
+
+var file = path.join(__dirname, '..', 'resources', 'tobeornottobe.txt');
+test_update('md5', file, '19e03260fad6a77c9f869079cedf664d');
+test_update('sha256', file,
+            '4e79cc2b93a9233a8b77c60971231431502b22c7cee1e2ebc10349a28d1852fa');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] ~~documentation is changed or added~~: no api change was made

fixed an issue that result of calculating hash from raw buffer is not correct
