### PR TITLE
benchmark: url.format

### DIFF
--- a/benchmark/url/append-url.js
+++ b/benchmark/url/append-url.js
@@ -1,0 +1,32 @@
+'use strict';
+
+var common = require('../common.js');
+var bench = common.createBenchmark(main, {
+  n: [128],
+});
+
+var urlObject = require('./url.json');
+
+function appendUrl (urlObject) {
+  var protocol = urlObject.protocol;
+  var hostname = urlObject.hostname;
+  var pathname = urlObject.pathname;
+  var url = `${protocol}://${hostname}/${pathname}`;
+  if (urlObject.query != null && Object.keys(urlObject.query).length > 0) {
+    var query = '?';
+    for (var key in urlObject.query) {
+      var value = urlObject.query[key];
+      query += `&${key}=${value}`;
+    }
+    url += query;
+  }
+  return url;
+}
+
+function main(opts) {
+  var n = opts.n;
+  bench.start();
+  for (var i = 0; i < n; ++i)
+    appendUrl(urlObject);
+  bench.end(n);
+}

--- a/benchmark/url/url-format.js
+++ b/benchmark/url/url-format.js
@@ -1,0 +1,17 @@
+'use strict';
+
+var common = require('../common.js');
+var bench = common.createBenchmark(main, {
+  n: [128],
+});
+
+var url = require('url');
+var urlObject = require('./url.json');
+
+function main(opts) {
+  var n = opts.n;
+  bench.start();
+  for (var i = 0; i < n; ++i)
+    url.format(urlObject);
+  bench.end(n);
+}

--- a/benchmark/url/url.json
+++ b/benchmark/url/url.json
@@ -1,0 +1,9 @@
+{
+  "protocol": "https",
+  "hostname": "example.com",
+  "pathname": "/foobar",
+  "query": {
+    "foo": "bar",
+    "query": "string"
+  }
+}


### PR DESCRIPTION
Benchmark results of appending url manually between formatting with `url.format`:

```
$ node benchmark/run url

url/append-url.js
url/append-url.js n=128: 136,929.44282553907

url/url-format.js
url/url-format.js n=128: 51,543.58956806069
```

```
$ iotjs benchmark/run url

url/append-url.js
url/append-url.js n=128: 10,643.118766396015

url/url-format.js
url/url-format.js n=128: 2,309.9444480015986
```