### PR TITLE
test: add test_net_https_destroy.js to testset

### DIFF
--- a/test/testsets.json
+++ b/test/testsets.json
@@ -90,6 +90,7 @@
     { "name": "test_net_httpclient_timeout_2.js" },
     { "name": "test_net_httpserver_timeout.js" },
     { "name": "test_net_httpserver.js", "skip": ["nuttx"], "reason": "not implemented for nuttx" },
+    { "name": "test_net_https_destroy.js" },
     { "name": "test_net_https_get.js", "timeout": 40, "skip": ["all"], "reason": "Implemented only for Tizen" },
     { "name": "test_net_https_post_status_codes.js", "timeout": 40, "skip": ["all"], "reason": "Implemented only for Tizen" },
     { "name": "test_net_https_request_response.js", "timeout": 40, "skip": ["all"], "reason": "Implemented only for Tizen" },


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included

We didn't include the case on `testsets.json` at #352, this is to fix the issue.
