### PR TITLE
leak: fix http/https and os leak

### DIFF
--- a/src/modules/iotjs_module_os.c
+++ b/src/modules/iotjs_module_os.c
@@ -111,6 +111,7 @@ JS_FUNCTION(GetInterfaceAddresses) {
     jerry_set_property_by_index(addrs, i, addr);
     jerry_release_value(addr);
   }
+  uv_free_interface_addresses(interfaces, (int)count);
   return addrs;
 }
 

--- a/test/node/parallel/test-http-abort.js
+++ b/test/node/parallel/test-http-abort.js
@@ -12,10 +12,10 @@ function getHandle(url) {
   throw new Error('unsupported url ' + url);
 }
 
-// // test http_client
-test('http://www.example.com/');
-// // test https_client
-test('https://www.example.com/');
+// test http_client
+test('http://example.com/');
+// test https_client
+test('https://example.com/');
 // unreachable tunnels, manually abort them
 var req1 = test('http://127.0.0.2');
 setTimeout(function () {
@@ -33,7 +33,6 @@ function test(url) {
   var handle = getHandle(url);
   var req = handle.get(url, function(res) {
     res.on('data', function(chunk) {
-      console.log(`${url} ondata`);
       assert.strictEqual(isAborted, false, `${url} should not aborted`);
       isAborted = true;
       req.abort();
@@ -46,12 +45,10 @@ function test(url) {
   });
 
   req.on('abort', common.mustCall(function() {
-    console.log(`${url} aborted`);
     eventTriggered = true;
   }));
 
   req.socket.on('close', common.mustCall(function() {
-    console.log(`${url} socket closed`);
   }));
 
   req.end();

--- a/test/node/parallel/test-http-abort.js
+++ b/test/node/parallel/test-http-abort.js
@@ -1,6 +1,7 @@
 var http = require('http');
 var https = require('https');
 var assert = require('assert');
+var common = require('../common')
 
 function getHandle(url) {
   if (/^http:\/\//.test(url)) {
@@ -11,10 +12,19 @@ function getHandle(url) {
   throw new Error('unsupported url ' + url);
 }
 
-// test http_client
-test('http://example.com/');
-// test https_client
-test('https://example.com/');
+// // test http_client
+test('http://www.example.com/');
+// // test https_client
+test('https://www.example.com/');
+// unreachable tunnels, manually abort them
+var req1 = test('http://127.0.0.2');
+setTimeout(function () {
+  req1.abort();
+}, 1000)
+var req2 = test('https://127.0.0.2');
+setTimeout(function () {
+  req2.abort();
+}, 1000)
 
 function test(url) {
   var isAborted = false;
@@ -23,20 +33,27 @@ function test(url) {
   var handle = getHandle(url);
   var req = handle.get(url, function(res) {
     res.on('data', function(chunk) {
-      assert.strictEqual(isAborted, false, 'should not aborted');
+      console.log(`${url} ondata`)
+      assert.strictEqual(isAborted, false, `${url} should not aborted`);
       isAborted = true;
       req.abort();
       process.nextTick(function() {
-        assert.strictEqual(eventTriggered, true, 'should trigger event abort');
+        assert.strictEqual(eventTriggered, true, `${url} should trigger event abort`);
       });
       chunks.push(chunk);
     });
 
   });
 
-  req.on('abort', function() {
+  req.on('abort', common.mustCall(function() {
+    console.log(`${url} aborted`)
     eventTriggered = true;
-  });
+  }));
+
+  req.socket.on('close', common.mustCall(function() {
+    console.log(`${url} socket closed`);
+  }));
 
   req.end();
+  return req;
 }

--- a/test/node/parallel/test-http-abort.js
+++ b/test/node/parallel/test-http-abort.js
@@ -20,11 +20,11 @@ test('https://www.example.com/');
 var req1 = test('http://127.0.0.2');
 setTimeout(function () {
   req1.abort();
-}, 1000)
+}, 1000);
 var req2 = test('https://127.0.0.2');
 setTimeout(function () {
   req2.abort();
-}, 1000)
+}, 1000);
 
 function test(url) {
   var isAborted = false;
@@ -33,7 +33,7 @@ function test(url) {
   var handle = getHandle(url);
   var req = handle.get(url, function(res) {
     res.on('data', function(chunk) {
-      console.log(`${url} ondata`)
+      console.log(`${url} ondata`);
       assert.strictEqual(isAborted, false, `${url} should not aborted`);
       isAborted = true;
       req.abort();
@@ -46,7 +46,7 @@ function test(url) {
   });
 
   req.on('abort', common.mustCall(function() {
-    console.log(`${url} aborted`)
+    console.log(`${url} aborted`);
     eventTriggered = true;
   }));
 


### PR DESCRIPTION
1. when the network is disconnected,  the socket cloud not been destroyed if the HTTP/HTTPS request through ip
2. invoke uv_free_interface_addresses to free uv_interface_address_t*
3. remove the 'lookup' event listener in https 