### PR TITLE
mqtt: clean up the keepalive timer when disconnecting

### DIFF
--- a/test/run_pass/test_mqtt_client.js
+++ b/test/run_pass/test_mqtt_client.js
@@ -1,0 +1,19 @@
+'use strict';
+
+var testHost = 'mqtt://test.mosquitto.org:1883';
+var mqtt = require('mqtt');
+var assert = require('assert');
+
+var disconnected = false;
+var client = mqtt.connect(testHost, {
+  reconnectPeriod: -1
+});
+client.once('connect', function() {
+  client.disconnect();
+  assert.equal(client._keepAliveTimer, null);
+  assert.equal(client._keepAliveTimeout, null);
+  disconnected = true;
+});
+client.once('offline', function() {
+  assert.ok(disconnected);
+});

--- a/test/run_pass/test_mqtt_sub_pub.js
+++ b/test/run_pass/test_mqtt_sub_pub.js
@@ -1,0 +1,42 @@
+'use strict';
+
+var mqtt = require('mqtt');
+var assert = require('assert');
+var bridge = 'mqtt://test.mosquitto.org:1883';
+
+var opts = {
+  reconnectPeriod: -1,
+};
+
+function connect(endpoint, opts) {
+  return new Promise(function (resolve, reject) {
+    var client = mqtt.connect(endpoint, opts);
+    client.once('connect', function() {
+      resolve(client);
+    });
+  });
+}
+
+Promise.all([
+  connect(bridge, opts),
+  connect(bridge, opts),
+]).then((results) => {
+  var yorkie = results[0];
+  var babeee = results[1];
+
+  babeee.subscribe('u/love', function() {
+    console.log('babeee subscribed u/love');
+    setTimeout(function() {
+      yorkie.publish('u/love', 'endless');
+      console.log('yorkie sent endless love');
+    }, 500);
+  });
+  babeee.on('message', function(channel, message) {
+    assert.equal(channel, 'u/love');
+    assert.equal(message + '', 'endless');
+    console.log('babeee receives the message from yorkie');
+
+    babeee.disconnect();
+    yorkie.disconnect();
+  });
+});

--- a/test/testsets.json
+++ b/test/testsets.json
@@ -67,6 +67,8 @@
         "NODE_PATH": "require2/node_modules"
       }
     },
+    { "name": "test_mqtt_client.js" },
+    { "name": "test_mqtt_sub_pub.js" },
     { "name": "test_net_1.js" },
     { "name": "test_net_2.js" },
     { "name": "test_net_3.js", "skip": ["linux", "nuttx"], "reason": "[linux]: flaky on Travis, [nuttx]: requires too many socket descriptors and too large buffers" },


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added

The timer for *Keep Alive* should be cleared if we explicitly disconnect it.

/cc @lolBig @legendecas 