### PR TITLE
promise: optimize the performance on .then and static resolve

### DIFF
--- a/benchmark/promise/resolve-empty-array.js
+++ b/benchmark/promise/resolve-empty-array.js
@@ -1,0 +1,21 @@
+'use strict';
+
+var common = require('../common.js');
+var bench = common.createBenchmark(main, {
+  n: [128],
+});
+
+function main(opts) {
+  var n = opts.n;
+  var future = Promise.resolve([]);
+  bench.start();
+
+  for (var i = 0; i < n; ++i) {
+    future = future.then(() => {
+      return Promise.resolve([]);
+    });
+  }
+  future.then(() => {
+    bench.end(n);
+  });
+}

--- a/benchmark/promise/resolve-statically.js
+++ b/benchmark/promise/resolve-statically.js
@@ -1,0 +1,19 @@
+'use strict';
+
+var common = require('../common.js');
+var bench = common.createBenchmark(main, {
+  n: [128],
+});
+
+function main(opts) {
+  var n = opts.n;
+  var future = Promise.resolve();
+  bench.start();
+
+  for (var i = 0; i < n; ++i) {
+    future = future.then(Promise.resolve);
+  }
+  future.then(() => {
+    bench.end(n);
+  });
+}

--- a/benchmark/promise/then.js
+++ b/benchmark/promise/then.js
@@ -1,0 +1,21 @@
+'use strict';
+
+var common = require('../common.js');
+var bench = common.createBenchmark(main, {
+  n: [128],
+});
+
+function main(opts) {
+  var n = opts.n;
+  var future = Promise.resolve();
+  bench.start();
+
+  for (var i = 0; i < n; ++i) {
+    future = future.then(() => {
+      return true;
+    });
+  }
+  future.then(() => {
+    bench.end(n);
+  });
+}

--- a/src/js/promise.js
+++ b/src/js/promise.js
@@ -24,23 +24,43 @@
  * Version 487e452.
  */
 
-'use strict';
-
 var STATE_PENDING = 0;
 var STATE_FULFILLED = 1;
 var STATE_REJECTED = 2;
 var STATE_NEXT = 3;
+
+// freeze the following static for performance
+var emptyPromise = freezePromiseOnResolve(undefined);
+var emptyArrayPromise = freezePromiseOnResolve([]);
+var nullPromise = freezePromiseOnResolve(null);
+var truePromise = freezePromiseOnResolve(true);
+var falsePromise = freezePromiseOnResolve(false);
+
+function freezePromiseOnResolve(value) {
+  var self = new Promise(noop);
+  resolve(self, value);
+  self._handled = true;
+  return Object.freeze(self);
+}
+
+function noop() {
+  // for then
+}
 
 function Promise(fn) {
   if (!(this instanceof Promise))
     throw new TypeError('undefined is not a promise');
   if (typeof fn !== 'function')
     throw new TypeError('Promise resolver undefined is not a function');
+
   this._state = STATE_PENDING;
   this._handled = false;
   this._value = undefined;
   this._deferreds = [];
 
+  if (fn === noop) {
+    return;
+  }
   doResolve(fn, this);
 }
 
@@ -122,12 +142,6 @@ function finale(self) {
   self._deferreds = null;
 }
 
-function Handler(onFulfilled, onRejected, promise) {
-  this.onFulfilled = typeof onFulfilled === 'function' ? onFulfilled : null;
-  this.onRejected = typeof onRejected === 'function' ? onRejected : null;
-  this.promise = promise;
-}
-
 /**
  * Take a potentially misbehaving resolver function and make sure
  * onFulfilled and onRejected are only called once.
@@ -161,10 +175,13 @@ Promise.prototype.catch = function(onRejected) {
 };
 
 Promise.prototype.then = function(onFulfilled, onRejected) {
-  var prom = new this.constructor(function() {
-    // Do nothing
+  // .then() is always needed to be a new instance.
+  var prom = new this.constructor(noop);
+  handle(this, {
+    onFulfilled: typeof onFulfilled === 'function' ? onFulfilled : null,
+    onRejected: typeof onRejected === 'function' ? onRejected : null,
+    promise: prom,
   });
-  handle(this, new Handler(onFulfilled, onRejected, prom));
   return prom;
 };
 
@@ -194,6 +211,7 @@ Promise.all = function(arr) {
       return [data];
     });
   }
+
   return new Promise(function(resolve, reject) {
     var remaining = args.length;
 
@@ -226,19 +244,37 @@ Promise.all = function(arr) {
 };
 
 Promise.resolve = function(value) {
+  // detect the value and returns the freezed promise directly
+  // only works for: `undefined`, `null`, `true`, `false` and array(0).
+  if (value === undefined) {
+    return emptyPromise;
+  } else if (value === null) {
+    return nullPromise;
+  } else if (value === true) {
+    return truePromise;
+  } else if (value === false) {
+    return falsePromise;
+  } else if (Array.isArray(value) && value.length === 0) {
+    return emptyArrayPromise;
+  }
+
   if (value && typeof value === 'object' && value.constructor === Promise) {
     return value;
   }
 
-  return new Promise(function(resolve) {
-    resolve(value);
-  });
+  // Promise.resolve asserts no error handling is required, just call
+  // resolve reduces the function calls.
+  var self = new Promise(noop);
+  resolve(self, value);
+  return self;
 };
 
 Promise.reject = function(value) {
-  return new Promise(function(resolve, reject) {
-    reject(value);
-  });
+  // Promise.resolve asserts no error handling is required, just call
+  // resolve reduces the function calls.
+  var self = new Promise(noop);
+  reject(self, value);
+  return self;
 };
 
 Promise.race = function(values) {

--- a/src/js/promise.js
+++ b/src/js/promise.js
@@ -24,6 +24,8 @@
  * Version 487e452.
  */
 
+/*eslint-disable */
+
 var STATE_PENDING = 0;
 var STATE_FULFILLED = 1;
 var STATE_REJECTED = 2;


### PR DESCRIPTION
The optimized `Promise` comparison:

| versions | 1 | 2 | 3 | 4 | 5 | Avg |
|----------|--|--|--|--|--|--|
| `before#then` | 2,500 | 2,189 | 2,560 | 2,716 | 2,191 | 2,431 |
| `after#then` | 3,056 | 3,149 | 3,383 | 3,270 | 3,694 | 3,310 |
| `before#resolve` | 1,717 | 1,589 | 1,744 | 1,684 | 1,770 | 1,700 |
| `after#resolve` | 2,848 | 2,764 | 3,433 | 2,622 | 3,023 | 2,938 |

The performance slots are:

- `then`, removes to create duplicated empty function, and creates at start.
- `Promise.resolve`:
  - skips `doResolve`, and immediately calls `resolve(self, value)` instead.
  - introduces freeze promise objects, currently for `undefined`, `true` and `false`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
