### PR TITLE
jerry: set prototype/constructor for external functions

### DIFF
--- a/deps/jerry/jerry-core/api/jerry.c
+++ b/deps/jerry/jerry-core/api/jerry.c
@@ -801,11 +801,11 @@ jerry_value_is_undefined (const jerry_value_t value) /**< api value */
  *         false - otherwise.
  */
 bool
-jerry_value_strict_equal(const jerry_value_t lhs, const jerry_value_t rhs)
+jerry_value_strict_equal (const jerry_value_t lhs, const jerry_value_t rhs)
 {
-  jerry_assert_api_available();
+  jerry_assert_api_available ();
 
-  return ecma_op_strict_equality_compare(lhs, rhs);
+  return ecma_op_strict_equality_compare (lhs, rhs);
 }
 
 
@@ -818,7 +818,7 @@ jerry_value_strict_equal(const jerry_value_t lhs, const jerry_value_t rhs)
 bool
 jerry_value_instanceof (const jerry_value_t value, const jerry_value_t proto)
 {
-  jerry_assert_api_available();
+  jerry_assert_api_available ();
 
   ecma_value_t ret = ecma_op_object_has_instance (ecma_get_object_from_value (proto), value);
   return ecma_is_value_true (ret);

--- a/deps/jerry/jerry-core/api/jerry.c
+++ b/deps/jerry/jerry-core/api/jerry.c
@@ -816,12 +816,12 @@ jerry_value_strict_equal(const jerry_value_t lhs, const jerry_value_t rhs)
  *         false - otherwise.
  */
 bool
-jerry_value_instanceof(const jerry_value_t value, const jerry_value_t proto)
+jerry_value_instanceof (const jerry_value_t value, const jerry_value_t proto)
 {
   jerry_assert_api_available();
 
-  ecma_value_t ret = ecma_op_object_has_instance(ecma_get_object_from_value(proto), value);
-  return ecma_is_value_true(ret);
+  ecma_value_t ret = ecma_op_object_has_instance (ecma_get_object_from_value (proto), value);
+  return ecma_is_value_true (ret);
 }
 
 /**

--- a/deps/jerry/jerry-core/ecma/operations/ecma-function-object.c
+++ b/deps/jerry/jerry-core/ecma/operations/ecma-function-object.c
@@ -911,8 +911,7 @@ ecma_op_function_try_to_lazy_instantiate_property (ecma_object_t *object_p, /**<
 /**
  * Create specification defined non-configurable properties for external functions.
  *
- * See also:
- *          ECMA-262 v5, 15.3.4.5
+ * There is no spec for external function, follow normal function behaviors.
  *
  * @return pointer property, if one was instantiated,
  *         NULL - otherwise.
@@ -925,6 +924,23 @@ ecma_op_external_function_try_to_lazy_instantiate_property (ecma_object_t *objec
 
   if (ecma_compare_ecma_string_to_magic_id (property_name_p, LIT_MAGIC_STRING_PROTOTYPE))
   {
+    /* ECMA-262 v5, 13.2, 16-18 */
+
+    /* 16. */
+    ecma_object_t *proto_object_p = ecma_op_create_object_object_noarg ();
+
+    /* 17. */
+    ecma_string_t *magic_string_constructor_p = ecma_get_magic_string (LIT_MAGIC_STRING_CONSTRUCTOR);
+
+    ecma_property_value_t *constructor_prop_value_p;
+    constructor_prop_value_p = ecma_create_named_data_property (proto_object_p,
+                                                                magic_string_constructor_p,
+                                                                ECMA_PROPERTY_CONFIGURABLE_WRITABLE,
+                                                                NULL);
+
+    constructor_prop_value_p->value = ecma_make_object_value (object_p);
+
+    /* 18. */
     ecma_property_t *prototype_prop_p;
     ecma_property_value_t *prototype_prop_value_p;
     prototype_prop_value_p = ecma_create_named_data_property (object_p,
@@ -932,7 +948,8 @@ ecma_op_external_function_try_to_lazy_instantiate_property (ecma_object_t *objec
                                                               ECMA_PROPERTY_FLAG_WRITABLE,
                                                               &prototype_prop_p);
 
-    prototype_prop_value_p->value = ECMA_VALUE_UNDEFINED;
+    prototype_prop_value_p->value = ecma_make_object_value (proto_object_p);
+    ecma_deref_object (proto_object_p);
     return prototype_prop_p;
   }
 

--- a/deps/jerry/tests/unit-core/test-api.c
+++ b/deps/jerry/tests/unit-core/test-api.c
@@ -143,6 +143,7 @@ handler_construct (const jerry_value_t func_obj_val, /**< function object */
   TEST_ASSERT (args_cnt == 1);
   TEST_ASSERT (jerry_value_is_boolean (args_p[0]));
   TEST_ASSERT (jerry_get_boolean_value (args_p[0]) == true);
+  TEST_ASSERT (jerry_value_instanceof (this_val, func_obj_val));
 
   jerry_value_t field_name = jerry_create_string ((jerry_char_t *) "value_field");
   jerry_set_property (this_val, field_name, args_p[0]);


### PR DESCRIPTION
External functions are treated as incomplete creation, which prototype is set to be undefined, which causes the `has_instance` doesn't work at external function.

This fixes #294 and #295.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
