### PR TITLE
build: add dependencies for iotjs.cmake which depends on others

### DIFF
--- a/cmake/iotjs.cmake
+++ b/cmake/iotjs.cmake
@@ -420,6 +420,13 @@ set(IOTJS_PUBLIC_HEADERS
 # Configure the libiotjs
 set(TARGET_LIB_IOTJS libiotjs)
 add_library(${TARGET_LIB_IOTJS} SHARED ${LIB_IOTJS_SRC})
+add_dependencies(${TARGET_LIB_IOTJS}
+  ${JERRY_LIBS}
+  ${TUV_LIBS}
+  libhttp-parser
+  ${MBEDTLS_LIBS}
+  ${MQTT_LIBS}
+)
 add_definitions(
   -DNODE_MAJOR_VERSION=${IOTJS_VERSION_MAJOR}
   -DNODE_MINOR_VERSION=${IOTJS_VERSION_MINOR}


### PR DESCRIPTION
Within some parallel builds, it occasionally gets a build error on libmqtt_packet depenedency.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
