### PR TITLE
events: cannot read property 'newListener' of undefined

### DIFF
--- a/src/js/events.js
+++ b/src/js/events.js
@@ -89,12 +89,12 @@ EventEmitter.prototype.addListener = function(type, listener) {
     throw new TypeError('listener must be a function');
   }
 
-  if (this._events.newListener !== undefined) {
-    this.emit('newListener', type, listener);
-  }
-
   if (!this._events) {
     this._events = Object.create(null);
+  }
+
+  if (this._events.newListener !== undefined) {
+    this.emit('newListener', type, listener);
   }
 
   existing = this._events[type];


### PR DESCRIPTION

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added

fixes an edge issue:
```js
var obj = {}
EventEmitter.prototype.on.apply(obj, ['foobar'])
```

as this is not an officially documented usage, test case is not included by intent.