### PR TITLE
n-api: code is optional on create error

### DIFF
--- a/src/napi/node_api_value.c
+++ b/src/napi/node_api_value.c
@@ -89,7 +89,6 @@ napi_status napi_create_object(napi_env env, napi_value* result) {
     jerry_value_t jval_code = AS_JERRY_VALUE(code);                           \
     jerry_value_t jval_msg = AS_JERRY_VALUE(msg);                             \
                                                                               \
-    NAPI_TRY_TYPE(string, jval_code);                                         \
     NAPI_TRY_TYPE(string, jval_msg);                                          \
                                                                               \
     jerry_size_t msg_size = jerry_get_utf8_string_size(jval_msg);             \
@@ -107,8 +106,12 @@ napi_status napi_create_object(napi_env env, napi_value* result) {
      * error flag.                                                            \
      */                                                                       \
     jerryx_create_handle(jval_error);                                         \
-                                                                              \
-    iotjs_jval_set_property_jval(jval_error, "code", jval_code);              \
+    /** code has to be an JS string type, thus it can not be an number 0 */   \
+    if (code != NULL) {                                                       \
+      NAPI_TRY_TYPE(string, jval_code);                                       \
+      iotjs_jval_set_property_jval(jval_error, IOTJS_MAGIC_STRING_CODE,       \
+                                   jval_code);                                \
+    }                                                                         \
     NAPI_ASSIGN(result, AS_NAPI_VALUE(jval_error));                           \
                                                                               \
     NAPI_RETURN(napi_ok);                                                     \

--- a/test/napi/napi_error.c
+++ b/test/napi/napi_error.c
@@ -39,6 +39,15 @@ static napi_value GetError(napi_env env, napi_callback_info info) {
   return error;
 }
 
+static napi_value GetNoCodeError(napi_env env, napi_callback_info info) {
+  napi_value error, message;
+  NAPI_CALL(env,
+            napi_create_string_utf8(env, "foobar", NAPI_AUTO_LENGTH, &message));
+  NAPI_CALL(env, napi_create_error(env, NULL, message, &error));
+
+  return error;
+}
+
 static napi_value Init(napi_env env, napi_value exports) {
   napi_value message;
   NAPI_CALL(env,
@@ -50,6 +59,7 @@ static napi_value Init(napi_env env, napi_value exports) {
   SET_NAMED_METHOD(env, error, "ThrowCreatedError", ThrowCreatedError);
   SET_NAMED_METHOD(env, error, "RethrowError", RethrowError);
   SET_NAMED_METHOD(env, error, "GetError", GetError);
+  SET_NAMED_METHOD(env, error, "GetNoCodeError", GetNoCodeError);
 
   NAPI_CALL(env, napi_throw(env, error));
 

--- a/test/napi/napi_error_throw.test.js
+++ b/test/napi/napi_error_throw.test.js
@@ -29,3 +29,9 @@ try {
 var err = test.GetError();
 assert(err != null);
 assert.strictEqual(err.message, 'foobar');
+assert.strictEqual(err.code, '');
+
+var err = test.GetNoCodeError();
+assert(err != null);
+assert.strictEqual(err.message, 'foobar');
+assert.strictEqual(err.code, undefined);


### PR DESCRIPTION

- [x] `npm test` passes
- [x] tests and/or benchmarks are included

According to N-API docs, second argument of napi_create_error/napi_create_type_error/napi_create_range_error shall be an optional string typed JS value.
