### PR TITLE
process: refactor nextTick

### DIFF
--- a/src/js/iotjs.js
+++ b/src/js/iotjs.js
@@ -475,46 +475,14 @@
     }
   }
 
-  var nextTickQueue = [];
+  var next_tick = Module.require('next_tick');
+  process.nextTick = next_tick.nextTick;
+  process._onNextTick = next_tick._onNextTick;
 
-  process.nextTick = nextTick;
-  process._onNextTick = _onNextTick;
   global.setImmediate = setImmediate;
-
-  function _onNextTick() {
-    // clone nextTickQueue to new array object, and calls function
-    // iterating the cloned array. This is because,
-    // during processing nextTick
-    // a callback could add another next tick callback using
-    // `process.nextTick()`, if we calls back iterating original
-    // `nextTickQueue` that could turn into infinite loop.
-
-    var callbacks = nextTickQueue.slice(0);
-    nextTickQueue = [];
-
-    var len = callbacks.length;
-    for (var i = 0; i < len; ++i) {
-      try {
-        callbacks[i]();
-      } catch (e) {
-        process._onUncaughtException(e);
-      }
-    }
-
-    return nextTickQueue.length > 0;
-  }
-
-
-  function nextTick(callback) {
-    var args = Array.prototype.slice.call(arguments);
-    args[0] = null;
-    nextTickQueue.push(Function.prototype.bind.apply(callback, args));
-  }
-
-
   function setImmediate(callback) {
     // TODO(Yorkie): use nextTick for now...
-    nextTick(callback);
+    process.nextTick(callback);
   }
 
   var os = Module.require('os');

--- a/src/js/next_tick.js
+++ b/src/js/next_tick.js
@@ -1,0 +1,84 @@
+'use strict';
+
+function TickObject(callback, args) {
+  this.callback = callback;
+  this.args = args;
+}
+
+function NextTickQueue() {
+  this.head = null;
+  this.tail = null;
+  this.length = 0;
+}
+
+NextTickQueue.prototype.push = function push(v) {
+  var entry = { data: v, next: null };
+  if (this.length > 0)
+    this.tail.next = entry;
+  else
+    this.head = entry;
+  this.tail = entry;
+  ++this.length;
+};
+
+NextTickQueue.prototype.shift = function shift() {
+  if (this.length === 0)
+    return;
+  var ret = this.head.data;
+  if (this.length === 1)
+    this.head = this.tail = null;
+  else
+    this.head = this.head.next;
+  --this.length;
+  return ret;
+};
+
+NextTickQueue.prototype.clear = function clear() {
+  this.head = null;
+  this.tail = null;
+  this.length = 0;
+};
+
+var nextTickQueue = new NextTickQueue();
+
+module.exports.nextTick = function nextTick(callback) {
+  var args;
+  switch (arguments.length) {
+    case 1: break;
+    case 2: args = [arguments[1]]; break;
+    case 3: args = [arguments[1], arguments[2]]; break;
+    case 4: args = [arguments[1], arguments[2], arguments[3]]; break;
+    default:
+      args = new Array(arguments.length - 1);
+      for (var i = 1; i < arguments.length; i++)
+        args[i - 1] = arguments[i];
+  }
+  var tickObject = new TickObject(callback, args);
+  nextTickQueue.push(tickObject);
+};
+
+module.exports._onNextTick = function _onNextTick() {
+  while (nextTickQueue.length > 0) {
+    var tickObject = nextTickQueue.shift();
+    var callback = tickObject.callback;
+    var args = tickObject.args;
+    if (args === undefined) {
+      callback();
+    } else {
+      switch (args.length) {
+        case 1:
+          callback(args[0]);
+          break;
+        case 2:
+          callback(args[0], args[1]);
+          break;
+        case 3:
+          callback(args[0], args[1], args[2]);
+          break;
+        default:
+          callback.apply(undefined, args);
+      }
+    }
+  }
+  return false;
+};

--- a/src/js/next_tick.js
+++ b/src/js/next_tick.js
@@ -13,22 +13,25 @@ function NextTickQueue() {
 
 NextTickQueue.prototype.push = function push(v) {
   var entry = { data: v, next: null };
-  if (this.length > 0)
+  if (this.length > 0) {
     this.tail.next = entry;
-  else
+  } else {
     this.head = entry;
+  }
   this.tail = entry;
   ++this.length;
 };
 
 NextTickQueue.prototype.shift = function shift() {
-  if (this.length === 0)
+  if (this.length === 0) {
     return;
+  }
   var ret = this.head.data;
-  if (this.length === 1)
+  if (this.length === 1) {
     this.head = this.tail = null;
-  else
+  } else {
     this.head = this.head.next;
+  }
   --this.length;
   return ret;
 };
@@ -50,8 +53,10 @@ module.exports.nextTick = function nextTick(callback) {
     case 4: args = [arguments[1], arguments[2], arguments[3]]; break;
     default:
       args = new Array(arguments.length - 1);
-      for (var i = 1; i < arguments.length; i++)
+      for (var i = 1; i < arguments.length; i++) {
         args[i - 1] = arguments[i];
+      }
+      break;
   }
   var tickObject = new TickObject(callback, args);
   nextTickQueue.push(tickObject);
@@ -66,17 +71,10 @@ module.exports._onNextTick = function _onNextTick() {
       callback();
     } else {
       switch (args.length) {
-        case 1:
-          callback(args[0]);
-          break;
-        case 2:
-          callback(args[0], args[1]);
-          break;
-        case 3:
-          callback(args[0], args[1], args[2]);
-          break;
-        default:
-          callback.apply(undefined, args);
+        case 1: callback(args[0]); break;
+        case 2: callback(args[0], args[1]); break;
+        case 3: callback(args[0], args[1], args[2]); break;
+        default: callback.apply(undefined, args); break;
       }
     }
   }

--- a/src/modules.json
+++ b/src/modules.json
@@ -13,6 +13,7 @@
         "https",
         "mqtt",
         "net",
+        "next_tick",
         "os",
         "path",
         "profiler",
@@ -292,6 +293,9 @@
     "net": {
       "js_file": "js/net.js",
       "require": ["assert", "events", "stream", "tcp", "util"]
+    },
+    "next_tick": {
+      "js_file": "js/next_tick.js"
     },
     "os": {
       "js_file": "js/os.js",

--- a/test/run_pass/test_process_next_tick.js
+++ b/test/run_pass/test_process_next_tick.js
@@ -16,26 +16,118 @@
 var assert = require('assert');
 
 
-var tickTrace = '';
+var trace1 = '';
+var trace2 = '';
+var trace3 = '';
+var trace4 = '';
+var trace5 = '';
 
-process.nextTick(function() {
-  tickTrace += '1';
+function test1() {
   process.nextTick(function() {
-    tickTrace += '2';
+    trace1 += '1';
     process.nextTick(function() {
-      tickTrace += '3';
+      trace1 += '2';
       process.nextTick(function() {
-        tickTrace += '4';
+        trace1 += '3';
         process.nextTick(function() {
-          tickTrace += '5';
+          trace1 += '4';
+          process.nextTick(function() {
+            trace1 += '5';
+          });
         });
       });
     });
   });
-});
+}
 
+function test2() {
+  process.nextTick(function () {
+    trace2 += '1';
+  });
+  process.nextTick(function () {
+    trace2 += '2';
+  })
+  setImmediate(function () {
+    trace2 += '3';
+    process.nextTick(function () {
+      trace2 += '5';
+    });
+  });
+  setImmediate(function () {
+    trace2 += '4';
+  });
+}
+
+function test3() {
+  process.nextTick(function () {
+    trace3 += '1';
+  });
+  process.nextTick(function () {
+    trace3 += '2';
+  })
+  setTimeout(function() {
+    trace3 += '3';
+    // FIXME
+    // when the timer is triggered,
+    // the js callback is called by iotjs_make_callback and therefore
+    // the nextTick callbacks is called
+    process.nextTick(function () {
+      trace3 += '4';
+    })
+  }, 0);
+  setTimeout(function() {
+    trace3 += '5';
+  }, 0);
+}
+
+function test4() {
+  process.nextTick(function(){
+    trace4 += '3';
+  });
+
+  new Promise(function(resolve){
+    trace4 += '1';
+    resolve();
+    trace4 += '2';
+  }).then(function(){
+    trace4 += '4';
+  });
+
+  process.nextTick(function(){
+    trace4 += '5';
+  });
+}
+
+function test5() {
+  setTimeout(function(){
+    trace5 += '5'
+  },0);
+
+  new Promise(function(resolve,reject){
+    trace5 += '1';
+    resolve();
+  }).then(function(){
+    trace5 += '2';
+  }).then(function(){
+    trace5 += '4';
+  });
+
+  process.nextTick(function(){
+    trace5 += '3';
+  });
+}
+
+test1();
+test2();
+test3();
+test4();
+test5();
 
 process.on('exit', function(code) {
   assert.equal(code, 0);
-  assert.equal(tickTrace, '12345');
+  assert.equal(trace1, '12345');
+  assert.equal(trace2, '12345');
+  assert.equal(trace3, '12345');
+  assert.equal(trace4, '12345');
+  assert.equal(trace5, '12345');
 });


### PR DESCRIPTION
- [x]   npm test passes
- [x]   tests and/or benchmarks are included

- separate the implementation of nextTick into another file
- use list instead of array to storage the callbacks
- optimizes the invocation performance of the callbacks
- handle all callbacks in a tick. in the previous implementation, a clone nextTickQueue is used to iterating, this will lead to a problem that a nextTick callback added by a calling nextTick callback can not be called in a same tick.
