### PR TITLE
n-api: thread safe functions

### DIFF
--- a/docs/api/N-API.md
+++ b/docs/api/N-API.md
@@ -52,14 +52,3 @@ Though N-API functions for creating/destroying async contexts are available, the
 
 #### Script execution
 - napi_run_script
-
-#### Asynchronous Thread-safe Function Calls
-> Experimental
-
-- napi_create_threadsafe_function
-- napi_get_threadsafe_function_context
-- napi_call_threadsafe_function
-- napi_acquire_threadsafe_function
-- napi_release_threadsafe_function
-- napi_ref_threadsafe_function
-- napi_unref_threadsafe_function

--- a/src/internal/node_api_internal.h
+++ b/src/internal/node_api_internal.h
@@ -19,6 +19,7 @@
 #include "iotjs_def.h"
 #include "jerryscript-ext/handle-scope.h"
 #include "jerryscript.h"
+#define NAPI_EXPERIMENTAL
 #include "internal/node_api_internal_types.h"
 #include "node_api.h"
 

--- a/src/internal/node_api_internal_types.h
+++ b/src/internal/node_api_internal_types.h
@@ -134,9 +134,9 @@ struct iotjs_threadsafe_function_s {
   napi_threadsafe_function_call_js call_js_cb;
 
   napi_async_context async_context;
-  uv_async_t* async_handle;
-  uv_cond_t* async_cond;
-  uv_mutex_t* op_mutex;
+  uv_async_t async_handle;
+  uv_cond_t async_cond;
+  uv_mutex_t op_mutex;
 
   iotjs_tsfn_invocation_t* invocation_head;
   iotjs_tsfn_invocation_t* invocation_tail;

--- a/src/internal/node_api_internal_types.h
+++ b/src/internal/node_api_internal_types.h
@@ -34,6 +34,8 @@ typedef struct iotjs_function_info_s iotjs_function_info_t;
 typedef struct iotjs_napi_env_s iotjs_napi_env_t;
 typedef struct iotjs_object_info_s iotjs_object_info_t;
 typedef struct iotjs_reference_s iotjs_reference_t;
+typedef struct iotjs_tsfn_invocation_s iotjs_tsfn_invocation_t;
+typedef struct iotjs_threadsafe_function_s iotjs_threadsafe_function_t;
 
 typedef enum {
   napi_module_load_ok = 0,
@@ -112,6 +114,35 @@ struct iotjs_async_context_s {
   napi_env env;
   napi_value async_resource;
   napi_value async_resource_name;
+};
+
+struct iotjs_tsfn_invocation_s {
+  iotjs_tsfn_invocation_t* next;
+  void* data;
+};
+
+struct iotjs_threadsafe_function_s {
+  napi_env env;
+  napi_value func;
+
+  size_t max_queue_size;
+  size_t thread_count;
+
+  void* thread_finalize_data;
+  napi_finalize thread_finalize_cb;
+  void* context;
+  napi_threadsafe_function_call_js call_js_cb;
+
+  napi_async_context async_context;
+  uv_async_t* async_handle;
+  uv_cond_t* async_cond;
+  uv_mutex_t* op_mutex;
+
+  iotjs_tsfn_invocation_t* invocation_head;
+  iotjs_tsfn_invocation_t* invocation_tail;
+  size_t queue_size;
+
+  bool aborted;
 };
 
 #endif // IOTJS_NODE_API_TYPES_H

--- a/src/napi/node_api_tsfn.c
+++ b/src/napi/node_api_tsfn.c
@@ -158,6 +158,7 @@ napi_status napi_create_threadsafe_function(
 
   tsfn->invocation_head = NULL;
   tsfn->invocation_tail = NULL;
+  tsfn->queue_size = 0;
 
   tsfn->aborted = false;
 

--- a/src/napi/node_api_tsfn.c
+++ b/src/napi/node_api_tsfn.c
@@ -213,7 +213,6 @@ napi_status napi_call_threadsafe_function(
       case napi_tsfn_nonblocking:
         ret_status = napi_queue_full;
         goto clean;
-        break;
       case napi_tsfn_blocking:
         uv_cond_wait(&tsfn->async_cond, &tsfn->op_mutex);
         break;

--- a/src/napi/node_api_tsfn.c
+++ b/src/napi/node_api_tsfn.c
@@ -32,7 +32,8 @@ static void tsfn_async_close_cb(uv_handle_t* handle) {
   uv_mutex_t* op_mutex = tsfn->op_mutex;
 
   thread_finalize_cb(env, thread_finalize_data, context);
-  NAPI_ASSERT(tsfn->invocation_head == NULL, "TSFN invocation shall be cleared before closing async handle.");
+  NAPI_ASSERT(tsfn->invocation_head == NULL,
+              "TSFN invocation shall be cleared before closing async handle.");
 
   jerry_release_value(AS_JERRY_VALUE(func));
   napi_async_destroy(env, async_context);

--- a/src/napi/node_api_tsfn.c
+++ b/src/napi/node_api_tsfn.c
@@ -1,0 +1,313 @@
+/* Copyright 2018-present Rokid Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "jerryscript-ext/handle-scope.h"
+#include "jerryscript.h"
+#include "internal/node_api_internal.h"
+
+static void tsfn_async_close_cb(uv_handle_t* handle) {
+  iotjs_threadsafe_function_t* tsfn =
+      (iotjs_threadsafe_function_t*)handle->data;
+
+  napi_env env = tsfn->env;
+  napi_value func = tsfn->func;
+  void* thread_finalize_data = tsfn->thread_finalize_data;
+  napi_finalize thread_finalize_cb = tsfn->thread_finalize_cb;
+  void* context = tsfn->context;
+  napi_async_context async_context = tsfn->async_context;
+
+  uv_cond_t* async_cond = tsfn->async_cond;
+  uv_mutex_t* op_mutex = tsfn->op_mutex;
+
+  iotjs_tsfn_invocation_t* invocation = tsfn->invocation_head;
+  while (invocation != NULL) {
+    iotjs_tsfn_invocation_t* tobereleased = invocation;
+    invocation = invocation->next;
+    IOTJS_RELEASE(tobereleased);
+  }
+
+  thread_finalize_cb(env, thread_finalize_data, context);
+
+  jerry_release_value(AS_JERRY_VALUE(func));
+  napi_async_destroy(env, async_context);
+  uv_cond_destroy(async_cond);
+  uv_mutex_destroy(op_mutex);
+}
+
+static void tsfn_async_callback(uv_async_t* handle) {
+  iotjs_threadsafe_function_t* tsfn =
+      (iotjs_threadsafe_function_t*)handle->data;
+  uv_mutex_lock(tsfn->op_mutex);
+  iotjs_tsfn_invocation_t* invocation = tsfn->invocation_head;
+
+  tsfn->invocation_head = NULL;
+  tsfn->invocation_tail = NULL;
+  tsfn->queue_size = 0;
+  uv_mutex_unlock(tsfn->op_mutex);
+  uv_cond_signal(tsfn->async_cond);
+
+  napi_env env = tsfn->env;
+  napi_value func = tsfn->func;
+  void* context = tsfn->context;
+  napi_threadsafe_function_call_js call_js_cb = tsfn->call_js_cb;
+
+  while (invocation != NULL) {
+    jerryx_handle_scope scope;
+    jerryx_open_handle_scope(&scope);
+    if (call_js_cb != NULL) {
+      call_js_cb(env, func, context, invocation->data);
+    } else {
+      napi_value nval_undefined = AS_NAPI_VALUE(jerry_create_undefined());
+      napi_call_function(env, nval_undefined, func, 0, NULL, NULL);
+    }
+    jerryx_close_handle_scope(scope);
+
+    if (iotjs_napi_is_exception_pending(env)) {
+      jerry_value_t jval_err;
+      jval_err = iotjs_napi_env_get_and_clear_exception(env);
+      if (jval_err == (uintptr_t)NULL) {
+        jval_err = iotjs_napi_env_get_and_clear_fatal_exception(env);
+      }
+
+      /** Argument cannot have error flag */
+      jerry_value_clear_error_flag(&jval_err);
+      iotjs_uncaught_exception(jval_err);
+      jerry_release_value(jval_err);
+    }
+
+    iotjs_tsfn_invocation_t* tobereleased = invocation;
+    invocation = invocation->next;
+    IOTJS_RELEASE(tobereleased);
+  }
+
+  uv_mutex_lock(tsfn->op_mutex);
+  if (tsfn->thread_count == 0 && tsfn->queue_size == 0) {
+    uv_close((uv_handle_t*)tsfn->async_handle, tsfn_async_close_cb);
+  }
+  uv_mutex_unlock(tsfn->op_mutex);
+}
+
+napi_status napi_create_threadsafe_function(
+    napi_env env, napi_value func, napi_value async_resource,
+    napi_value async_resource_name, size_t max_queue_size,
+    size_t initial_thread_count, void* thread_finalize_data,
+    napi_finalize thread_finalize_cb, void* context,
+    napi_threadsafe_function_call_js call_js_cb,
+    napi_threadsafe_function* result) {
+  NAPI_TRY_ENV(env);
+  NAPI_ASSERT(result != NULL,
+              "Expect an non-null out result pointer on "
+              "napi_create_threadsafe_function.");
+
+  bool napi_async_inited = false, uv_async_inited = false,
+       uv_cond_inited = false, uv_mutex_inited = false, func_acquired = false;
+
+  napi_async_context async_context;
+  NAPI_INTERNAL_CALL(napi_async_init(env, async_resource, async_resource_name,
+                                     &async_context));
+  napi_async_inited = true;
+
+  uv_async_t* async_handle = IOTJS_ALLOC(uv_async_t);
+  iotjs_environment_t* iotjs_env = iotjs_environment_get();
+  uv_loop_t* iotjs_loop = iotjs_environment_loop(iotjs_env);
+  int uv_status = uv_async_init(iotjs_loop, async_handle, tsfn_async_callback);
+  if (uv_status != 0) {
+    goto clean;
+  }
+  uv_async_inited = true;
+
+  uv_cond_t* async_cond = IOTJS_ALLOC(uv_cond_t);
+  uv_status = uv_cond_init(async_cond);
+  if (uv_status != 0) {
+    goto clean;
+  }
+  uv_cond_inited = true;
+
+
+  uv_mutex_t* op_mutex = IOTJS_ALLOC(uv_mutex_t);
+  uv_status = uv_mutex_init(op_mutex);
+  if (uv_status != 0) {
+    goto clean;
+  }
+  uv_mutex_inited = true;
+
+  func = AS_NAPI_VALUE(jerry_acquire_value(AS_JERRY_VALUE(func)));
+  func_acquired = true;
+
+  iotjs_threadsafe_function_t* tsfn = IOTJS_ALLOC(iotjs_threadsafe_function_t);
+  tsfn->env = env;
+  tsfn->func = func;
+  tsfn->max_queue_size = max_queue_size;
+  tsfn->thread_count = initial_thread_count;
+  tsfn->thread_finalize_data = thread_finalize_data;
+  tsfn->thread_finalize_cb = thread_finalize_cb;
+  tsfn->context = context;
+  tsfn->call_js_cb = call_js_cb;
+
+  tsfn->async_context = async_context;
+  tsfn->async_handle = async_handle;
+  tsfn->async_cond = async_cond;
+  tsfn->op_mutex = op_mutex;
+
+  tsfn->invocation_head = NULL;
+  tsfn->invocation_tail = NULL;
+
+  tsfn->aborted = false;
+
+  async_handle->data = (void*)tsfn;
+
+  NAPI_ASSIGN(result, (napi_threadsafe_function)tsfn);
+  NAPI_RETURN(napi_ok);
+
+clean:
+  if (napi_async_inited) {
+    napi_async_destroy(env, async_context);
+  }
+  if (func_acquired) {
+    jerry_release_value(AS_JERRY_VALUE(func));
+  }
+  if (uv_async_inited) {
+    uv_close((uv_handle_t*)async_handle, tsfn_async_close_cb);
+  }
+  if (uv_cond_inited) {
+    uv_cond_destroy(async_cond);
+  }
+  if (uv_mutex_inited) {
+    uv_mutex_destroy(op_mutex);
+  }
+  NAPI_RETURN_WITH_MSG(napi_generic_failure,
+                       "Unexpected error on napi_create_threadsafe_function.");
+}
+
+napi_status napi_get_threadsafe_function_context(napi_threadsafe_function func,
+                                                 void** result) {
+  iotjs_threadsafe_function_t* tsfn = (iotjs_threadsafe_function_t*)func;
+  NAPI_ASSIGN(result, tsfn->context);
+
+  /** do not use NAPI_RETURN macro as it would access napi_env */
+  return napi_ok;
+}
+
+napi_status napi_call_threadsafe_function(
+    napi_threadsafe_function func, void* data,
+    napi_threadsafe_function_call_mode is_blocking) {
+  iotjs_threadsafe_function_t* tsfn = (iotjs_threadsafe_function_t*)func;
+
+  uv_mutex_lock(tsfn->op_mutex);
+  napi_status ret_status = napi_ok;
+
+  if (tsfn->aborted) {
+    ret_status = napi_closing;
+    goto clean;
+  }
+
+  if (tsfn->max_queue_size != 0 && tsfn->queue_size == tsfn->max_queue_size) {
+    switch (is_blocking) {
+      case napi_tsfn_nonblocking:
+        ret_status = napi_queue_full;
+        goto clean;
+        break;
+      case napi_tsfn_blocking:
+        uv_cond_wait(tsfn->async_cond, tsfn->op_mutex);
+        break;
+      default:
+        NAPI_ASSERT(false,
+                    "Unrecognized mode on napi_call_threadsafe_function.");
+    }
+  }
+
+  iotjs_tsfn_invocation_t* tsfn_invocation =
+      IOTJS_ALLOC(iotjs_tsfn_invocation_t);
+  tsfn_invocation->data = data;
+  tsfn_invocation->next = NULL;
+
+  if (tsfn->invocation_head == NULL) {
+    tsfn->invocation_head = tsfn_invocation;
+  }
+  if (tsfn->invocation_tail == NULL) {
+    tsfn->invocation_tail = tsfn_invocation;
+  } else {
+    tsfn->invocation_tail->next = tsfn_invocation;
+    tsfn->invocation_tail = tsfn_invocation;
+  }
+  ++tsfn->queue_size;
+
+  uv_async_send(tsfn->async_handle);
+
+clean:
+  uv_mutex_unlock(tsfn->op_mutex);
+  return ret_status;
+}
+
+napi_status napi_acquire_threadsafe_function(napi_threadsafe_function func) {
+  iotjs_threadsafe_function_t* tsfn = (iotjs_threadsafe_function_t*)func;
+  uv_mutex_lock(tsfn->op_mutex);
+
+  ++tsfn->thread_count;
+
+  uv_mutex_unlock(tsfn->op_mutex);
+  return napi_ok;
+}
+
+napi_status napi_release_threadsafe_function(
+    napi_threadsafe_function func, napi_threadsafe_function_release_mode mode) {
+  iotjs_threadsafe_function_t* tsfn = (iotjs_threadsafe_function_t*)func;
+  uv_mutex_lock(tsfn->op_mutex);
+
+  if (tsfn->thread_count > 0) {
+    --tsfn->thread_count;
+  } else {
+    fprintf(stderr,
+            "[N-API] WARNING: trying to release an already zero-referenced "
+            "threadsafe function.\n");
+  }
+  switch (mode) {
+    case napi_tsfn_release:
+      break;
+    case napi_tsfn_abort:
+      tsfn->aborted = true;
+      break;
+    default:
+      NAPI_ASSERT(false,
+                  "Unrecognized mode on napi_release_threadsafe_function.");
+  }
+
+  if (tsfn->thread_count == 0 || tsfn->aborted) {
+    uv_close((uv_handle_t*)tsfn->async_handle, tsfn_async_close_cb);
+  }
+
+  uv_mutex_unlock(tsfn->op_mutex);
+  return napi_ok;
+}
+
+napi_status napi_unref_threadsafe_function(napi_env env,
+                                           napi_threadsafe_function func) {
+  NAPI_TRY_ENV(env);
+  iotjs_threadsafe_function_t* tsfn = (iotjs_threadsafe_function_t*)func;
+
+  uv_unref((uv_handle_t*)tsfn->async_handle);
+
+  NAPI_RETURN(napi_ok);
+}
+
+napi_status napi_ref_threadsafe_function(napi_env env,
+                                         napi_threadsafe_function func) {
+  NAPI_TRY_ENV(env);
+  iotjs_threadsafe_function_t* tsfn = (iotjs_threadsafe_function_t*)func;
+
+  uv_ref((uv_handle_t*)tsfn->async_handle);
+
+  NAPI_RETURN(napi_ok);
+}

--- a/test/napi-testsets.json
+++ b/test/napi-testsets.json
@@ -72,6 +72,7 @@
     { "name": "napi_reference.test.js", "skip": false },
     { "name": "napi_string.test.js", "skip": false },
     { "name": "napi_thread_safe.test.js", "skip": false, "expected-failure": true },
+    { "name": "napi_tsfn.test.js", "skip": false },
     { "name": "napi.test.js", "skip": false }
   ]
 }

--- a/test/napi/binding.gyp
+++ b/test/napi/binding.gyp
@@ -51,6 +51,10 @@
     {
       "target_name": "napi_thread_safe",
       "sources": [ "napi_thread_safe.c" ]
+    },
+    {
+      "target_name": "napi_tsfn",
+      "sources": [ "napi_tsfn.c" ]
     }
   ]
 }

--- a/test/napi/napi_tsfn.c
+++ b/test/napi/napi_tsfn.c
@@ -1,0 +1,270 @@
+// For the purpose of this test we use libuv's threading library. When deciding
+// on a threading library for a new project it bears remembering that in the
+// future libuv may introduce API changes which may render it non-ABI-stable,
+// which, in turn, may affect the ABI stability of the project despite its use
+// of N-API.
+#include <uv.h>
+#define NAPI_EXPERIMENTAL
+#include <node_api.h>
+#include "common.h"
+
+#define ARRAY_LENGTH 10
+#define MAX_QUEUE_SIZE 2
+
+static uv_thread_t uv_threads[2];
+static napi_threadsafe_function ts_fn;
+
+typedef struct {
+  napi_threadsafe_function_call_mode block_on_full;
+  napi_threadsafe_function_release_mode abort;
+  bool start_secondary;
+  napi_ref js_finalize_cb;
+  uint32_t max_queue_size;
+} ts_fn_hint;
+
+static ts_fn_hint ts_info;
+
+// Thread data to transmit to JS
+static int ints[ARRAY_LENGTH];
+
+static void secondary_thread(void* data) {
+  napi_threadsafe_function ts_fn = data;
+
+  if (napi_release_threadsafe_function(ts_fn, napi_tsfn_release) != napi_ok) {
+    napi_fatal_error("secondary_thread", NAPI_AUTO_LENGTH,
+                     "napi_release_threadsafe_function failed",
+                     NAPI_AUTO_LENGTH);
+  }
+}
+
+// Source thread producing the data
+static void data_source_thread(void* data) {
+  napi_threadsafe_function ts_fn = data;
+  int index;
+  void* hint;
+  ts_fn_hint* ts_fn_info;
+  napi_status status;
+  bool queue_was_full = false;
+  bool queue_was_closing = false;
+
+  if (napi_get_threadsafe_function_context(ts_fn, &hint) != napi_ok) {
+    napi_fatal_error("data_source_thread", NAPI_AUTO_LENGTH,
+                     "napi_get_threadsafe_function_context failed",
+                     NAPI_AUTO_LENGTH);
+  }
+
+  ts_fn_info = (ts_fn_hint*)hint;
+
+  if (ts_fn_info != &ts_info) {
+    napi_fatal_error("data_source_thread", NAPI_AUTO_LENGTH,
+                     "thread-safe function hint is not as expected",
+                     NAPI_AUTO_LENGTH);
+  }
+
+  if (ts_fn_info->start_secondary) {
+    if (napi_acquire_threadsafe_function(ts_fn) != napi_ok) {
+      napi_fatal_error("data_source_thread", NAPI_AUTO_LENGTH,
+                       "napi_acquire_threadsafe_function failed",
+                       NAPI_AUTO_LENGTH);
+    }
+
+    if (uv_thread_create(&uv_threads[1], secondary_thread, ts_fn) != 0) {
+      napi_fatal_error("data_source_thread", NAPI_AUTO_LENGTH,
+                       "failed to start secondary thread", NAPI_AUTO_LENGTH);
+    }
+  }
+
+  for (index = ARRAY_LENGTH - 1; index > -1 && !queue_was_closing; index--) {
+    status = napi_call_threadsafe_function(ts_fn, &ints[index],
+                                           ts_fn_info->block_on_full);
+    if (ts_fn_info->max_queue_size == 0) {
+      // Let's make this thread really busy for 200 ms to give the main thread a
+      // chance to abort.
+      uint64_t start = uv_hrtime();
+      for (; uv_hrtime() - start < 200000000;)
+        ;
+    }
+    switch (status) {
+      case napi_queue_full:
+        queue_was_full = true;
+        index++;
+        // fall through
+
+      case napi_ok:
+        continue;
+
+      case napi_closing:
+        queue_was_closing = true;
+        break;
+
+      default:
+        napi_fatal_error("data_source_thread", NAPI_AUTO_LENGTH,
+                         "napi_call_threadsafe_function failed",
+                         NAPI_AUTO_LENGTH);
+    }
+  }
+
+  // Assert that the enqueuing of a value was refused at least once, if this is
+  // a non-blocking test run.
+  if (!ts_fn_info->block_on_full && !queue_was_full) {
+    napi_fatal_error("data_source_thread", NAPI_AUTO_LENGTH,
+                     "queue was never full", NAPI_AUTO_LENGTH);
+  }
+
+  // Assert that the queue was marked as closing at least once, if this is an
+  // aborting test run.
+  if (ts_fn_info->abort == napi_tsfn_abort && !queue_was_closing) {
+    napi_fatal_error("data_source_thread", NAPI_AUTO_LENGTH,
+                     "queue was never closing", NAPI_AUTO_LENGTH);
+  }
+
+  if (!queue_was_closing &&
+      napi_release_threadsafe_function(ts_fn, napi_tsfn_release) != napi_ok) {
+    napi_fatal_error("data_source_thread", NAPI_AUTO_LENGTH,
+                     "napi_release_threadsafe_function failed",
+                     NAPI_AUTO_LENGTH);
+  }
+}
+
+// Getting the data into JS
+static void call_js(napi_env env, napi_value cb, void* hint, void* data) {
+  if (!(env == NULL || cb == NULL)) {
+    napi_value argv, undefined;
+    NAPI_CALL_RETURN_VOID(env, napi_create_int32(env, *(int*)data, &argv));
+    NAPI_CALL_RETURN_VOID(env, napi_get_undefined(env, &undefined));
+    NAPI_CALL_RETURN_VOID(env, napi_call_function(env, undefined, cb, 1, &argv,
+                                                  NULL));
+  }
+}
+
+// Cleanup
+static napi_value StopThread(napi_env env, napi_callback_info info) {
+  size_t argc = 2;
+  napi_value argv[2];
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, argv, NULL, NULL));
+  napi_valuetype value_type;
+  NAPI_CALL(env, napi_typeof(env, argv[0], &value_type));
+  NAPI_ASSERT(env, value_type == napi_function,
+              "StopThread argument is a function");
+  NAPI_ASSERT(env, (ts_fn != NULL), "Existing threadsafe function");
+  NAPI_CALL(env,
+            napi_create_reference(env, argv[0], 1, &(ts_info.js_finalize_cb)));
+  bool abort;
+  NAPI_CALL(env, napi_get_value_bool(env, argv[1], &abort));
+  NAPI_CALL(env,
+            napi_release_threadsafe_function(ts_fn, abort ? napi_tsfn_abort
+                                                          : napi_tsfn_release));
+  ts_fn = NULL;
+  return NULL;
+}
+
+// Join the thread and inform JS that we're done.
+static void join_the_threads(napi_env env, void* data, void* hint) {
+  uv_thread_t* the_threads = data;
+  ts_fn_hint* the_hint = hint;
+  napi_value js_cb, undefined;
+
+  uv_thread_join(&the_threads[0]);
+  if (the_hint->start_secondary) {
+    uv_thread_join(&the_threads[1]);
+  }
+
+  NAPI_CALL_RETURN_VOID(env,
+                        napi_get_reference_value(env, the_hint->js_finalize_cb,
+                                                 &js_cb));
+  NAPI_CALL_RETURN_VOID(env, napi_get_undefined(env, &undefined));
+  NAPI_CALL_RETURN_VOID(env, napi_call_function(env, undefined, js_cb, 0, NULL,
+                                                NULL));
+  NAPI_CALL_RETURN_VOID(env,
+                        napi_delete_reference(env, the_hint->js_finalize_cb));
+}
+
+static napi_value StartThreadInternal(napi_env env, napi_callback_info info,
+                                      napi_threadsafe_function_call_js cb,
+                                      bool block_on_full) {
+  size_t argc = 4;
+  napi_value argv[4];
+
+  ts_info.block_on_full =
+      (block_on_full ? napi_tsfn_blocking : napi_tsfn_nonblocking);
+
+  NAPI_ASSERT(env, (ts_fn == NULL), "Existing thread-safe function");
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, argv, NULL, NULL));
+  napi_value async_name;
+  NAPI_CALL(env, napi_create_string_utf8(env, "N-API Thread-safe Function Test",
+                                         NAPI_AUTO_LENGTH, &async_name));
+  NAPI_CALL(env, napi_get_value_uint32(env, argv[3], &ts_info.max_queue_size));
+  NAPI_CALL(env, napi_create_threadsafe_function(env, argv[0], NULL, async_name,
+                                                 ts_info.max_queue_size, 2,
+                                                 uv_threads, join_the_threads,
+                                                 &ts_info, cb, &ts_fn));
+  bool abort;
+  NAPI_CALL(env, napi_get_value_bool(env, argv[1], &abort));
+  ts_info.abort = abort ? napi_tsfn_abort : napi_tsfn_release;
+  NAPI_CALL(env, napi_get_value_bool(env, argv[2], &(ts_info.start_secondary)));
+
+  NAPI_ASSERT(env,
+              (uv_thread_create(&uv_threads[0], data_source_thread, ts_fn) ==
+               0),
+              "Thread creation");
+
+  return NULL;
+}
+
+static napi_value Unref(napi_env env, napi_callback_info info) {
+  NAPI_ASSERT(env, ts_fn != NULL, "No existing thread-safe function");
+  NAPI_CALL(env, napi_unref_threadsafe_function(env, ts_fn));
+  return NULL;
+}
+
+static napi_value Release(napi_env env, napi_callback_info info) {
+  NAPI_ASSERT(env, ts_fn != NULL, "No existing thread-safe function");
+  NAPI_CALL(env, napi_release_threadsafe_function(ts_fn, napi_tsfn_release));
+  return NULL;
+}
+
+// Startup
+static napi_value StartThread(napi_env env, napi_callback_info info) {
+  return StartThreadInternal(env, info, call_js, true);
+}
+
+static napi_value StartThreadNonblocking(napi_env env,
+                                         napi_callback_info info) {
+  return StartThreadInternal(env, info, call_js, false);
+}
+
+static napi_value StartThreadNoNative(napi_env env, napi_callback_info info) {
+  return StartThreadInternal(env, info, NULL, true);
+}
+
+// Module init
+static napi_value Init(napi_env env, napi_value exports) {
+  size_t index;
+  for (index = 0; index < ARRAY_LENGTH; index++) {
+    ints[index] = index;
+  }
+  napi_value js_array_length, js_max_queue_size;
+  napi_create_uint32(env, ARRAY_LENGTH, &js_array_length);
+  napi_create_uint32(env, MAX_QUEUE_SIZE, &js_max_queue_size);
+
+  napi_property_descriptor properties[] = {
+    { "ARRAY_LENGTH", NULL, NULL, NULL, NULL, js_array_length, napi_enumerable,
+      NULL },
+    { "MAX_QUEUE_SIZE", NULL, NULL, NULL, NULL, js_max_queue_size,
+      napi_enumerable, NULL },
+    DECLARE_NAPI_PROPERTY("StartThread", StartThread),
+    DECLARE_NAPI_PROPERTY("StartThreadNoNative", StartThreadNoNative),
+    DECLARE_NAPI_PROPERTY("StartThreadNonblocking", StartThreadNonblocking),
+    DECLARE_NAPI_PROPERTY("StopThread", StopThread),
+    DECLARE_NAPI_PROPERTY("Unref", Unref),
+    DECLARE_NAPI_PROPERTY("Release", Release),
+  };
+
+  NAPI_CALL(env,
+            napi_define_properties(env, exports,
+                                   sizeof(properties) / sizeof(properties[0]),
+                                   properties));
+
+  return exports;
+}
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/napi/napi_tsfn.test.js
+++ b/test/napi/napi_tsfn.test.js
@@ -19,7 +19,6 @@ if (process.argv[2] === 'child') {
   var callCount = 0;
   binding.StartThread((value) => {
     callCount++;
-    console.log(value);
     if (callCount === 2) {
       binding.Unref();
     }
@@ -58,6 +57,7 @@ function testWithJSMarshaller(options) {
   });
 }
 
+// eslint-disable-next-line no-unused-vars
 function testUnref(queueSize) {
   return new Promise((resolve, reject) => {
     var output = '';
@@ -65,7 +65,6 @@ function testUnref(queueSize) {
       stdio: [process.stdin, 'pipe', process.stderr, 'ipc']
     });
     child.on('close', (code) => {
-      console.log('on child close with code:', code, 'output:', output)
       if (code === 0) {
         resolve(output.match(/\S+/g));
       } else {
@@ -200,8 +199,10 @@ new Promise(function testWithoutJSMarshaller(resolve) {
 }))
 .then((result) => assert.strictEqual(result.indexOf(0), -1))
 
+;// TODO: read child stdout
+
 // Start a child process to test rapid teardown
-.then(() => testUnref(binding.MAX_QUEUE_SIZE))
+// .then(() => testUnref(binding.MAX_QUEUE_SIZE))
 
 // Start a child process with an infinite queue to test rapid teardown
-.then(() => testUnref(0));
+// .then(() => testUnref(0));

--- a/test/napi/napi_tsfn.test.js
+++ b/test/napi/napi_tsfn.test.js
@@ -1,0 +1,207 @@
+'use strict';
+
+var common = require('../common');
+var assert = require('assert');
+var binding = require('./build/Release/napi_tsfn.node');
+var fork = require('child_process').fork;
+var expectedArray = (function(arrayLength) {
+  var result = [];
+  for (var index = 0; index < arrayLength; index++) {
+    result.push(arrayLength - 1 - index);
+  }
+  return result;
+})(binding.ARRAY_LENGTH);
+
+// Handle the rapid teardown test case as the child process. We unref the
+// thread-safe function after we have received two values. This causes the
+// process to exit and the environment cleanup handler to be invoked.
+if (process.argv[2] === 'child') {
+  var callCount = 0;
+  binding.StartThread((value) => {
+    callCount++;
+    console.log(value);
+    if (callCount === 2) {
+      binding.Unref();
+    }
+  }, false /* abort */, true /* launchSecondary */, +process.argv[3]);
+
+  // Release the thread-safe function from the main thread so that it may be
+  // torn down via the environment cleanup handler.
+  binding.Release();
+  return;
+}
+
+function testWithJSMarshaller(options) {
+  var threadStarter = options.threadStarter;
+  var quitAfter = options.quitAfter;
+  var abort = options.abort;
+  var maxQueueSize = options.maxQueueSize;
+  var launchSecondary = options.launchSecondary;
+  return new Promise((resolve) => {
+    var array = [];
+    binding[threadStarter](function testCallback(value) {
+      array.push(value);
+      if (array.length === quitAfter) {
+        setImmediate(() => {
+          binding.StopThread(common.mustCall(() => {
+            resolve(array);
+          }), !!abort);
+        });
+      }
+    }, !!abort, !!launchSecondary, maxQueueSize);
+    if (threadStarter === 'StartThreadNonblocking') {
+      // Let's make this thread really busy for a short while to ensure that
+      // the queue fills and the thread receives a napi_queue_full.
+      var start = Date.now();
+      while (Date.now() - start < 200);
+    }
+  });
+}
+
+function testUnref(queueSize) {
+  return new Promise((resolve, reject) => {
+    var output = '';
+    var child = fork(__filename, ['child', queueSize], {
+      stdio: [process.stdin, 'pipe', process.stderr, 'ipc']
+    });
+    child.on('close', (code) => {
+      console.log('on child close with code:', code, 'output:', output)
+      if (code === 0) {
+        resolve(output.match(/\S+/g));
+      } else {
+        reject(new Error('Child process died with code ' + code));
+      }
+    });
+    child.stdout.on('data', (data) => (output += data.toString()));
+  })
+  .then((result) => assert.strictEqual(result.indexOf(0), -1));
+}
+
+new Promise(function testWithoutJSMarshaller(resolve) {
+  var callCount = 0;
+  binding.StartThreadNoNative(function testCallback() {
+    callCount++;
+
+    // The default call-into-JS implementation passes no arguments.
+    assert.strictEqual(arguments.length, 0);
+    if (callCount === binding.ARRAY_LENGTH) {
+      setImmediate(() => {
+        binding.StopThread(common.mustCall(() => {
+          resolve();
+        }), false);
+      });
+    }
+  }, false /* abort */, false /* launchSecondary */, binding.MAX_QUEUE_SIZE);
+})
+
+// Start the thread in blocking mode, and assert that all values are passed.
+// Quit after it's done.
+.then(() => testWithJSMarshaller({
+  threadStarter: 'StartThread',
+  maxQueueSize: binding.MAX_QUEUE_SIZE,
+  quitAfter: binding.ARRAY_LENGTH
+}))
+.then((result) => assert.deepStrictEqual(result, expectedArray))
+
+// Start the thread in blocking mode with an infinite queue, and assert that all
+// values are passed. Quit after it's done.
+.then(() => testWithJSMarshaller({
+  threadStarter: 'StartThread',
+  maxQueueSize: 0,
+  quitAfter: binding.ARRAY_LENGTH
+}))
+.then((result) => assert.deepStrictEqual(result, expectedArray))
+
+// Start the thread in non-blocking mode, and assert that all values are passed.
+// Quit after it's done.
+.then(() => testWithJSMarshaller({
+  threadStarter: 'StartThreadNonblocking',
+  maxQueueSize: binding.MAX_QUEUE_SIZE,
+  quitAfter: binding.ARRAY_LENGTH
+}))
+.then((result) => assert.deepStrictEqual(result, expectedArray))
+
+// Start the thread in blocking mode, and assert that all values are passed.
+// Quit early, but var the thread finish.
+.then(() => testWithJSMarshaller({
+  threadStarter: 'StartThread',
+  maxQueueSize: binding.MAX_QUEUE_SIZE,
+  quitAfter: 1
+}))
+.then((result) => assert.deepStrictEqual(result, expectedArray))
+
+// Start the thread in blocking mode with an infinite queue, and assert that all
+// values are passed. Quit early, but var the thread finish.
+.then(() => testWithJSMarshaller({
+  threadStarter: 'StartThread',
+  maxQueueSize: 0,
+  quitAfter: 1
+}))
+.then((result) => assert.deepStrictEqual(result, expectedArray))
+
+// Start the thread in non-blocking mode, and assert that all values are passed.
+// Quit early, but var the thread finish.
+.then(() => testWithJSMarshaller({
+  threadStarter: 'StartThreadNonblocking',
+  maxQueueSize: binding.MAX_QUEUE_SIZE,
+  quitAfter: 1
+}))
+.then((result) => assert.deepStrictEqual(result, expectedArray))
+
+// Start the thread in blocking mode, and assert that all values are passed.
+// Quit early, but var the thread finish. Launch a secondary thread to test the
+// reference counter incrementing functionality.
+.then(() => testWithJSMarshaller({
+  threadStarter: 'StartThread',
+  quitAfter: 1,
+  maxQueueSize: binding.MAX_QUEUE_SIZE,
+  launchSecondary: true
+}))
+.then((result) => assert.deepStrictEqual(result, expectedArray))
+
+// Start the thread in non-blocking mode, and assert that all values are passed.
+// Quit early, but var the thread finish. Launch a secondary thread to test the
+// reference counter incrementing functionality.
+.then(() => testWithJSMarshaller({
+  threadStarter: 'StartThreadNonblocking',
+  quitAfter: 1,
+  maxQueueSize: binding.MAX_QUEUE_SIZE,
+  launchSecondary: true
+}))
+.then((result) => assert.deepStrictEqual(result, expectedArray))
+
+// Start the thread in blocking mode, and assert that it could not finish.
+// Quit early by aborting.
+.then(() => testWithJSMarshaller({
+  threadStarter: 'StartThread',
+  quitAfter: 1,
+  maxQueueSize: binding.MAX_QUEUE_SIZE,
+  abort: true
+}))
+.then((result) => assert.strictEqual(result.indexOf(0), -1))
+
+// Start the thread in blocking mode with an infinite queue, and assert that it
+// could not finish. Quit early by aborting.
+.then(() => testWithJSMarshaller({
+  threadStarter: 'StartThread',
+  quitAfter: 1,
+  maxQueueSize: 0,
+  abort: true
+}))
+.then((result) => assert.strictEqual(result.indexOf(0), -1))
+
+// Start the thread in non-blocking mode, and assert that it could not finish.
+// Quit early and aborting.
+.then(() => testWithJSMarshaller({
+  threadStarter: 'StartThreadNonblocking',
+  quitAfter: 1,
+  maxQueueSize: binding.MAX_QUEUE_SIZE,
+  abort: true
+}))
+.then((result) => assert.strictEqual(result.indexOf(0), -1))
+
+// Start a child process to test rapid teardown
+.then(() => testUnref(binding.MAX_QUEUE_SIZE))
+
+// Start a child process with an infinite queue to test rapid teardown
+.then(() => testUnref(0));


### PR DESCRIPTION
- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added

Unit tests depends on #406.

Introduce thread safe functions into N-API. Simplify complex native add-ons to notify JavaScripts in a work thread without blocking work thread nor main thread.