### PR TITLE
util: IOTJS_ASSERT prints stack trace on macOS

### DIFF
--- a/src/iotjs_util.c
+++ b/src/iotjs_util.c
@@ -103,6 +103,7 @@ void print_stacktrace() {
   for (int idx = 0; idx < size; ++idx) {
     fprintf(stderr, "%s\n", bt_strs[idx]);
   }
+  free(bt_strs);
 #endif // (defined(__linux__) || defined(__APPLE__))
 }
 

--- a/src/iotjs_util.c
+++ b/src/iotjs_util.c
@@ -96,14 +96,13 @@ void iotjs_buffer_release(char* buffer) {
 
 void print_stacktrace() {
 #if (defined(__linux__) || defined(__APPLE__))
-  const int numOfStackTrace = 25;
-  void* bt[numOfStackTrace];
-  int size = backtrace(bt, numOfStackTrace);
-  char** bt_strs = backtrace_symbols(bt, size);
+  void* bt[IOTJS_BACKTRACE_LEN];
+  int size = backtrace(bt, IOTJS_BACKTRACE_LEN);
+  char** bt_sym_strs = backtrace_symbols(bt, size);
   for (int idx = 0; idx < size; ++idx) {
-    fprintf(stderr, "%s\n", bt_strs[idx]);
+    fprintf(stderr, "%s\n", bt_sym_strs[idx]);
   }
-  free(bt_strs);
+  free(bt_sym_strs);
 #endif // (defined(__linux__) || defined(__APPLE__))
 }
 

--- a/src/iotjs_util.c
+++ b/src/iotjs_util.c
@@ -21,7 +21,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#if defined(__linux__)
+#if defined(__linux__) || defined(__APPLE__)
 #include <execinfo.h>
 #endif
 
@@ -95,39 +95,15 @@ void iotjs_buffer_release(char* buffer) {
 }
 
 void print_stacktrace() {
-#if defined(__linux__) && defined(DEBUG)
-  // TODO: support other platforms
-  const int numOfStackTrace = 100;
-  void* buffer[numOfStackTrace];
-  char command[256];
-
-  int nptrs = backtrace(buffer, numOfStackTrace);
-  char** strings = backtrace_symbols(buffer, nptrs);
-
-  if (strings == NULL) {
-    perror("backtrace_symbols");
-    exit(EXIT_FAILURE);
+#if (defined(__linux__) || defined(__APPLE__))
+  const int numOfStackTrace = 25;
+  void* bt[numOfStackTrace];
+  int size = backtrace(bt, numOfStackTrace);
+  char** bt_strs = backtrace_symbols(bt, size);
+  for (int idx = 0; idx < size; ++idx) {
+    fprintf(stderr, "%s\n", bt_strs[idx]);
   }
-
-  printf("\n[Backtrace]:\n");
-  for (int j = 0; j < nptrs - 2; j++) { // remove the last two
-    int idx = 0;
-    while (strings[j][idx] != '\0') {
-      if (strings[j][idx] == '(') {
-        break;
-      }
-      idx++;
-    }
-    snprintf(command, sizeof(command), "addr2line %p -e %.*s", buffer[j], idx,
-             strings[j]);
-
-    if (system(command)) {
-      break;
-    }
-  }
-
-  free(strings);
-#endif // defined(__linux__) && defined(DEBUG)
+#endif // (defined(__linux__) || defined(__APPLE__))
 }
 
 void force_terminate() {

--- a/src/iotjs_util.h
+++ b/src/iotjs_util.h
@@ -18,6 +18,10 @@
 
 #include "iotjs_string.h"
 
+#ifndef IOTJS_BACKTRACE_LEN
+#define IOTJS_BACKTRACE_LEN 25
+#endif
+
 char* iotjs__file_read(const char* path, size_t* outlen);
 // Return value should be released with iotjs_string_destroy()
 iotjs_string_t iotjs_file_read(const char* path);

--- a/src/napi/node_api_env.c
+++ b/src/napi/node_api_env.c
@@ -212,10 +212,10 @@ void napi_fatal_error(const char* location, size_t location_len,
   printf("FATAL ERROR: %s %s\n", location, message);
   void* bt[NAPI_FATAL_BACKTRACE_LEN];
   int size = backtrace(bt, NAPI_FATAL_BACKTRACE_LEN);
-  char** bt_strs = backtrace_symbols(bt, size);
+  char** bt_sym_strs = backtrace_symbols(bt, size);
   for (int idx = 0; idx < size; ++idx) {
-    fprintf(stderr, "%s\n", bt_strs[idx]);
+    fprintf(stderr, "%s\n", bt_sym_strs[idx]);
   }
-  free(bt_strs);
+  free(bt_sym_strs);
   abort();
 }

--- a/src/napi/node_api_env.c
+++ b/src/napi/node_api_env.c
@@ -216,5 +216,6 @@ void napi_fatal_error(const char* location, size_t location_len,
   for (int idx = 0; idx < size; ++idx) {
     fprintf(stderr, "%s\n", bt_strs[idx]);
   }
+  free(bt_strs);
   abort();
 }


### PR DESCRIPTION
- [x] `npm test` passes
- [ ] tests and/or benchmarks are included

Currently stack trace only prints on linux platform. While macOS actually support backtrace too, this PR enables backtrace on macOS platform.