### PR TITLE
n-api: update n-api headers/test sets to LTS version 10.13.0

### DIFF
--- a/docs/api/N-API.md
+++ b/docs/api/N-API.md
@@ -52,3 +52,6 @@ Though N-API functions for creating/destroying async contexts are available, the
 
 #### Script execution
 - napi_run_script
+
+#### Experimental functions
+- napi_add_finalizer

--- a/include/node_api.h
+++ b/include/node_api.h
@@ -1,4 +1,4 @@
-// Pulled from nodejs/node#8742cbfef0d31d7fad49ced7d11e6827b932b101 v10.8.0 using tools/pull-napi.sh
+// Pulled from nodejs/node#daff0be5b31f769357d943f9694f866b7d286647 v10.13.0 using tools/pull-napi.sh
 
 #ifndef SRC_NODE_API_H_
 #define SRC_NODE_API_H_
@@ -600,7 +600,7 @@ NAPI_EXTERN napi_status napi_adjust_external_memory(napi_env env,
                                                     int64_t change_in_bytes,
                                                     int64_t* adjusted_value);
 
-// Runnig a script
+// Running a script
 NAPI_EXTERN napi_status napi_run_script(napi_env env,
                                         napi_value script,
                                         napi_value* result);
@@ -697,6 +697,12 @@ NAPI_EXTERN napi_status napi_get_value_bigint_words(napi_env env,
                                                     int* sign_bit,
                                                     size_t* word_count,
                                                     uint64_t* words);
+NAPI_EXTERN napi_status napi_add_finalizer(napi_env env,
+                                           napi_value js_object,
+                                           void* native_object,
+                                           napi_finalize finalize_cb,
+                                           void* finalize_hint,
+                                           napi_ref* result);
 #endif  // NAPI_EXPERIMENTAL
 
 EXTERN_C_END

--- a/include/node_api_types.h
+++ b/include/node_api_types.h
@@ -1,4 +1,4 @@
-// Pulled from nodejs/node#8742cbfef0d31d7fad49ced7d11e6827b932b101 v10.8.0 using tools/pull-napi.sh
+// Pulled from nodejs/node#daff0be5b31f769357d943f9694f866b7d286647 v10.13.0 using tools/pull-napi.sh
 
 #ifndef SRC_NODE_API_TYPES_H_
 #define SRC_NODE_API_TYPES_H_

--- a/test/addons-napi/7_factory_wrap/binding.cc
+++ b/test/addons-napi/7_factory_wrap/binding.cc
@@ -15,9 +15,14 @@ napi_value CreateObject(napi_env env, napi_callback_info info) {
 napi_value Init(napi_env env, napi_value exports) {
   NAPI_CALL(env, MyObject::Init(env));
 
-  NAPI_CALL(env,
-      // NOLINTNEXTLINE (readability/null_usage)
-      napi_create_function(env, "exports", -1, CreateObject, NULL, &exports));
+  napi_property_descriptor descriptors[] = {
+    DECLARE_NAPI_GETTER("finalizeCount", MyObject::GetFinalizeCount),
+    DECLARE_NAPI_PROPERTY("createObject", CreateObject),
+  };
+
+  NAPI_CALL(env, napi_define_properties(
+      env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
+
   return exports;
 }
 

--- a/test/addons-napi/7_factory_wrap/myobject.cc
+++ b/test/addons-napi/7_factory_wrap/myobject.cc
@@ -1,6 +1,8 @@
 #include "myobject.h"
 #include "../common.h"
 
+static int finalize_count = 0;
+
 MyObject::MyObject() : env_(nullptr), wrapper_(nullptr) {}
 
 MyObject::~MyObject() { napi_delete_reference(env_, wrapper_); }
@@ -8,8 +10,15 @@ MyObject::~MyObject() { napi_delete_reference(env_, wrapper_); }
 void MyObject::Destructor(napi_env env,
                           void* nativeObject,
                           void* /*finalize_hint*/) {
+  ++finalize_count;
   MyObject* obj = static_cast<MyObject*>(nativeObject);
   delete obj;
+}
+
+napi_value MyObject::GetFinalizeCount(napi_env env, napi_callback_info info) {
+  napi_value result;
+  NAPI_CALL(env, napi_create_int32(env, finalize_count, &result));
+  return result;
 }
 
 napi_ref MyObject::constructor;

--- a/test/addons-napi/7_factory_wrap/myobject.h
+++ b/test/addons-napi/7_factory_wrap/myobject.h
@@ -7,6 +7,7 @@ class MyObject {
  public:
   static napi_status Init(napi_env env);
   static void Destructor(napi_env env, void* nativeObject, void* finalize_hint);
+  static napi_value GetFinalizeCount(napi_env env, napi_callback_info info);
   static napi_status NewInstance(napi_env env,
                                  napi_value arg,
                                  napi_value* instance);

--- a/test/addons-napi/7_factory_wrap/test.js
+++ b/test/addons-napi/7_factory_wrap/test.js
@@ -1,14 +1,25 @@
 'use strict';
+// Flags: --expose-gc
+
 var common = require('../../common');
 var assert = require('assert');
-var createObject = require(`./build/Release/binding.node`);
+var test = require(`./build/Release/binding.node`);
 
-var obj = createObject(10);
-assert.strictEqual(obj.plusOne(), 11);
-assert.strictEqual(obj.plusOne(), 12);
-assert.strictEqual(obj.plusOne(), 13);
+assert.strictEqual(test.finalizeCount, 0);
+(() => {
+  var obj = test.createObject(10);
+  assert.strictEqual(obj.plusOne(), 11);
+  assert.strictEqual(obj.plusOne(), 12);
+  assert.strictEqual(obj.plusOne(), 13);
+})();
+global.gc();
+assert.strictEqual(test.finalizeCount, 1);
 
-var obj2 = createObject(20);
-assert.strictEqual(obj2.plusOne(), 21);
-assert.strictEqual(obj2.plusOne(), 22);
-assert.strictEqual(obj2.plusOne(), 23);
+(() => {
+  var obj2 = test.createObject(20);
+  assert.strictEqual(obj2.plusOne(), 21);
+  assert.strictEqual(obj2.plusOne(), 22);
+  assert.strictEqual(obj2.plusOne(), 23);
+})();
+global.gc();
+assert.strictEqual(test.finalizeCount, 2);

--- a/test/addons-napi/8_passing_wrapped/test.js
+++ b/test/addons-napi/8_passing_wrapped/test.js
@@ -12,5 +12,6 @@ assert.strictEqual(result, 30);
 
 // Make sure the native destructor gets called.
 obj1 = null;
+obj2 = null;
 global.gc();
-assert.strictEqual(addon.finalizeCount(), 1);
+assert.strictEqual(addon.finalizeCount(), 2);

--- a/test/addons-napi/README.md
+++ b/test/addons-napi/README.md
@@ -1,1 +1,1 @@
-Pulled from nodejs/node#8742cbfef0d31d7fad49ced7d11e6827b932b101 v10.8.0 using tools/pull-napi.sh
+Pulled from nodejs/node#daff0be5b31f769357d943f9694f866b7d286647 v10.13.0 using tools/pull-napi.sh

--- a/test/addons-napi/test_async/test-loop.js
+++ b/test/addons-napi/test_async/test-loop.js
@@ -6,7 +6,7 @@ var iterations = 500;
 
 var x = 0;
 var workDone = common.mustCall((status) => {
-  assert.strictEqual(status, 0, 'Work completed successfully');
+  assert.strictEqual(status, 0);
   if (++x < iterations) {
     setImmediate(() => test_async.DoRepeatedWork(workDone));
   }

--- a/test/addons-napi/test_general/testFinalizer.js
+++ b/test/addons-napi/test_general/testFinalizer.js
@@ -1,0 +1,32 @@
+'use strict';
+// Flags: --expose-gc
+
+var common = require('../../common');
+var test_general = require(`./build/Release/test_general.node`);
+var assert = require('assert');
+
+var finalized = {};
+var callback = common.mustCall(2);
+
+// Add two items to be finalized and ensure the callback is called for each.
+test_general.addFinalizerOnly(finalized, callback);
+test_general.addFinalizerOnly(finalized, callback);
+
+// Ensure attached items cannot be retrieved.
+common.expectsError(() => test_general.unwrap(finalized),
+                    { type: Error, message: 'Invalid argument' });
+
+// Ensure attached items cannot be removed.
+common.expectsError(() => test_general.removeWrap(finalized),
+                    { type: Error, message: 'Invalid argument' });
+finalized = null;
+global.gc();
+
+// Add an item to an object that is already wrapped, and ensure that its
+// finalizer as well as the wrap finalizer gets called.
+var finalizeAndWrap = {};
+test_general.wrap(finalizeAndWrap);
+test_general.addFinalizerOnly(finalizeAndWrap, common.mustCall());
+finalizeAndWrap = null;
+global.gc();
+assert.strictEqual(test_general.derefItemWasCalled(), true);


### PR DESCRIPTION
- [x] `npm test` passes
- [x] documentation is changed or added
