### PR TITLE
n-api: ArrayBuffer/TypedArray support

### DIFF
--- a/docs/api/N-API.md
+++ b/docs/api/N-API.md
@@ -11,11 +11,8 @@ Use [node-gyp](https://github.com/nodejs/node-gyp) whenever possible, since N-AP
 #### Working with JavaScript Values
 
 ##### Object Creation Functions
-- napi_create_arraybuffer
-- napi_create_external_arraybuffer
 - napi_create_external_buffer
 - napi_create_symbol
-- napi_create_typedarray
 - napi_create_dataview
 
 ##### Functions to convert from C types to N-API
@@ -26,8 +23,6 @@ Use [node-gyp](https://github.com/nodejs/node-gyp) whenever possible, since N-AP
 - napi_create_string_utf16
 
 ##### Functions to convert from N-API to C types
-- napi_get_arraybuffer_info
-- napi_get_typedarray_info
 - napi_get_dataview_info
 - napi_get_value_bigint_int64
 - napi_get_value_bigint_uint64

--- a/src/internal/node_api_internal_types.h
+++ b/src/internal/node_api_internal_types.h
@@ -25,7 +25,8 @@ typedef napi_value (*jerry_addon_register_func)(void* env,
                                                 jerry_value_t exports);
 typedef void (*iotjs_cleanup_hook_fn)(void* arg);
 
-
+typedef struct iotjs_arraybuffer_external_info_s
+    iotjs_arraybuffer_external_info_t;
 typedef struct iotjs_async_context_s iotjs_async_context_t;
 typedef struct iotjs_async_work_s iotjs_async_work_t;
 typedef struct iotjs_callback_info_s iotjs_callback_info_t;
@@ -43,6 +44,13 @@ typedef enum {
   napi_module_no_pending,
   napi_module_no_nm_register_func,
 } napi_module_load_status;
+
+struct iotjs_arraybuffer_external_info_s {
+  napi_env env;
+  void* external_data;
+  void* finalize_hint;
+  napi_finalize finalize_cb;
+};
 
 struct iotjs_cleanup_hook_s {
   iotjs_cleanup_hook_fn fn;

--- a/test/napi-testsets.json
+++ b/test/napi-testsets.json
@@ -73,6 +73,7 @@
     { "name": "napi_string.test.js", "skip": false },
     { "name": "napi_thread_safe.test.js", "skip": false, "expected-failure": true },
     { "name": "napi_tsfn.test.js", "skip": false },
+    { "name": "napi_typedarray.test.js", "skip": false },
     { "name": "napi.test.js", "skip": false }
   ]
 }

--- a/test/napi/binding.gyp
+++ b/test/napi/binding.gyp
@@ -55,6 +55,10 @@
     {
       "target_name": "napi_tsfn",
       "sources": [ "napi_tsfn.c" ]
+    },
+    {
+      "target_name": "napi_typedarray",
+      "sources": [ "napi_typedarray.c" ]
     }
   ]
 }

--- a/test/napi/napi_typedarray.c
+++ b/test/napi/napi_typedarray.c
@@ -1,0 +1,185 @@
+#include <node_api.h>
+#include <string.h>
+#include "common.h"
+
+static napi_value Multiply(napi_env env, napi_callback_info info) {
+  size_t argc = 2;
+  napi_value args[2];
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+
+  NAPI_ASSERT(env, argc == 2, "Wrong number of arguments");
+
+  napi_valuetype valuetype0;
+  NAPI_CALL(env, napi_typeof(env, args[0], &valuetype0));
+
+  NAPI_ASSERT(
+      env, valuetype0 == napi_object,
+      "Wrong type of arguments. Expects a typed array as first argument.");
+
+  napi_value input_array = args[0];
+  bool is_typedarray;
+  NAPI_CALL(env, napi_is_typedarray(env, input_array, &is_typedarray));
+
+  NAPI_ASSERT(
+      env, is_typedarray,
+      "Wrong type of arguments. Expects a typed array as first argument.");
+
+  napi_valuetype valuetype1;
+  NAPI_CALL(env, napi_typeof(env, args[1], &valuetype1));
+
+  NAPI_ASSERT(env, valuetype1 == napi_number,
+              "Wrong type of arguments. Expects a number as second argument.");
+
+  double multiplier;
+  NAPI_CALL(env, napi_get_value_double(env, args[1], &multiplier));
+
+  napi_typedarray_type type;
+  napi_value input_buffer;
+  size_t byte_offset;
+  size_t i, length;
+  NAPI_CALL(env, napi_get_typedarray_info(env, input_array, &type, &length,
+                                          NULL, &input_buffer, &byte_offset));
+
+  void* data;
+  size_t byte_length;
+  NAPI_CALL(env,
+            napi_get_arraybuffer_info(env, input_buffer, &data, &byte_length));
+
+  napi_value output_buffer;
+  void* output_ptr = NULL;
+  NAPI_CALL(env, napi_create_arraybuffer(env, byte_length, &output_ptr,
+                                         &output_buffer));
+
+  napi_value output_array;
+  NAPI_CALL(env, napi_create_typedarray(env, type, length, output_buffer,
+                                        byte_offset, &output_array));
+
+  if (type == napi_uint8_array) {
+    uint8_t* input_bytes = (uint8_t*)(data) + byte_offset;
+    uint8_t* output_bytes = (uint8_t*)(output_ptr);
+    for (i = 0; i < length; i++) {
+      output_bytes[i] = (uint8_t)(input_bytes[i] * multiplier);
+    }
+  } else if (type == napi_float64_array) {
+    double* input_doubles = (double*)((uint8_t*)(data) + byte_offset);
+    double* output_doubles = (double*)(output_ptr);
+    for (i = 0; i < length; i++) {
+      output_doubles[i] = input_doubles[i] * multiplier;
+    }
+  } else {
+    napi_throw_error(env, NULL,
+                     "Typed array was of a type not expected by test.");
+    return NULL;
+  }
+
+  return output_array;
+}
+
+static napi_value External(napi_env env, napi_callback_info info) {
+  static int8_t externalData[] = { 0, 1, 2 };
+
+  napi_value output_buffer;
+  NAPI_CALL(env, napi_create_external_arraybuffer(env, externalData,
+                                                  sizeof(externalData),
+                                                  NULL, // finalize_callback
+                                                  NULL, // finalize_hint
+                                                  &output_buffer));
+
+  napi_value output_array;
+  NAPI_CALL(env, napi_create_typedarray(env, napi_int8_array,
+                                        sizeof(externalData) / sizeof(int8_t),
+                                        output_buffer, 0, &output_array));
+
+  return output_array;
+}
+
+static napi_value CreateTypedArray(napi_env env, napi_callback_info info) {
+  size_t argc = 4;
+  napi_value args[4];
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+
+  NAPI_ASSERT(env, argc == 2 || argc == 4, "Wrong number of arguments");
+
+  napi_value input_array = args[0];
+  napi_valuetype valuetype0;
+  NAPI_CALL(env, napi_typeof(env, input_array, &valuetype0));
+
+  NAPI_ASSERT(
+      env, valuetype0 == napi_object,
+      "Wrong type of arguments. Expects a typed array as first argument.");
+
+  bool is_typedarray;
+  NAPI_CALL(env, napi_is_typedarray(env, input_array, &is_typedarray));
+
+  NAPI_ASSERT(
+      env, is_typedarray,
+      "Wrong type of arguments. Expects a typed array as first argument.");
+
+  napi_valuetype valuetype1;
+  napi_value input_buffer = args[1];
+  NAPI_CALL(env, napi_typeof(env, input_buffer, &valuetype1));
+
+  NAPI_ASSERT(
+      env, valuetype1 == napi_object,
+      "Wrong type of arguments. Expects an array buffer as second argument.");
+
+  bool is_arraybuffer;
+  NAPI_CALL(env, napi_is_arraybuffer(env, input_buffer, &is_arraybuffer));
+
+  NAPI_ASSERT(
+      env, is_arraybuffer,
+      "Wrong type of arguments. Expects an array buffer as second argument.");
+
+  napi_typedarray_type type;
+  napi_value in_array_buffer;
+  size_t byte_offset;
+  size_t length;
+  NAPI_CALL(env,
+            napi_get_typedarray_info(env, input_array, &type, &length, NULL,
+                                     &in_array_buffer, &byte_offset));
+
+  if (argc == 4) {
+    napi_valuetype valuetype2;
+    NAPI_CALL(env, napi_typeof(env, args[2], &valuetype2));
+
+    NAPI_ASSERT(env, valuetype2 == napi_number,
+                "Wrong type of arguments. Expects a number as third argument.");
+
+    uint32_t uint32_length;
+    NAPI_CALL(env, napi_get_value_uint32(env, args[2], &uint32_length));
+    length = uint32_length;
+
+    napi_valuetype valuetype3;
+    NAPI_CALL(env, napi_typeof(env, args[3], &valuetype3));
+
+    NAPI_ASSERT(env, valuetype3 == napi_number,
+                "Wrong type of arguments. Expects a number as third argument.");
+
+    uint32_t uint32_byte_offset;
+    NAPI_CALL(env, napi_get_value_uint32(env, args[3], &uint32_byte_offset));
+    byte_offset = uint32_byte_offset;
+  }
+
+  napi_value output_array;
+  NAPI_CALL(env, napi_create_typedarray(env, type, length, input_buffer,
+                                        byte_offset, &output_array));
+
+  return output_array;
+}
+
+static napi_value Init(napi_env env, napi_value exports) {
+  napi_property_descriptor descriptors[] = {
+    DECLARE_NAPI_PROPERTY("Multiply", Multiply),
+    DECLARE_NAPI_PROPERTY("External", External),
+    DECLARE_NAPI_PROPERTY("CreateTypedArray", CreateTypedArray),
+  };
+
+  NAPI_CALL(env,
+            napi_define_properties(env, exports,
+                                   sizeof(descriptors) / sizeof(*descriptors),
+                                   descriptors));
+
+  return exports;
+}
+
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/napi/napi_typedarray.test.js
+++ b/test/napi/napi_typedarray.test.js
@@ -1,0 +1,38 @@
+'use strict';
+var assert = require('assert');
+
+// Testing api calls for arrays
+var test_typedarray = require('./build/Release/napi_typedarray.node');
+
+var byteArray = new Uint8Array(3);
+byteArray[0] = 0;
+byteArray[1] = 1;
+byteArray[2] = 2;
+assert.strictEqual(byteArray.length, 3);
+
+var doubleArray = new Float64Array(3);
+doubleArray[0] = 0.0;
+doubleArray[1] = 1.1;
+doubleArray[2] = 2.2;
+assert.strictEqual(doubleArray.length, 3);
+
+var byteResult = test_typedarray.Multiply(byteArray, 3);
+assert.ok(byteResult instanceof Uint8Array);
+assert.strictEqual(byteResult.length, 3);
+assert.strictEqual(byteResult[0], 0);
+assert.strictEqual(byteResult[1], 3);
+assert.strictEqual(byteResult[2], 6);
+
+var doubleResult = test_typedarray.Multiply(doubleArray, -3);
+assert.ok(doubleResult instanceof Float64Array);
+assert.strictEqual(doubleResult.length, 3);
+assert.strictEqual(doubleResult[0], -0);
+assert.strictEqual(Math.round(10 * doubleResult[1]) / 10, -3.3);
+assert.strictEqual(Math.round(10 * doubleResult[2]) / 10, -6.6);
+
+var externalResult = test_typedarray.External();
+assert.ok(externalResult instanceof Int8Array);
+assert.strictEqual(externalResult.length, 3);
+assert.strictEqual(externalResult[0], 0);
+assert.strictEqual(externalResult[1], 1);
+assert.strictEqual(externalResult[2], 2);


### PR DESCRIPTION
##### TODO: 
- [x] ArrayBuffer jerry info api shall not do anything besides accessing info (#421).
- [x] ArrayBuffer external jerry free callback shall add an additional hint param (#421).
- [x] External ArrayBuffer free callback wrapper.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
