### PR TITLE
jerry: finalize hint for array buffers

### DIFF
--- a/deps/jerry/docs/02.API-REFERENCE.md
+++ b/deps/jerry/docs/02.API-REFERENCE.md
@@ -2733,11 +2733,13 @@ so the user can release the buffer which was provided.
 jerry_value_t
 jerry_create_arraybuffer_external (const jerry_length_t size
                                    uint8_t *buffer_p,
+                                   void *free_hint,
                                    jerry_object_native_free_callback_t free_cb);
 ```
 
 - `size` - size of the buffer to use **in bytes** (should not be 0)
 - `buffer_p` - the buffer used for the Array Buffer object (should not be a null pointer)
+- `free_hint` - hint param of buffer free callback
 - `free_cb` - the callback function called when the object is released
 - return value
   - the new ArrayBuffer as a `jerry_value_t`
@@ -2748,7 +2750,7 @@ jerry_create_arraybuffer_external (const jerry_length_t size
 ```c
 {
   uint8_t buffer_p[15];
-  jerry_value_t buffer_value = jerry_create_arraybuffer_external (15, buffer_p, NULL);
+  jerry_value_t buffer_value = jerry_create_arraybuffer_external (15, buffer_p, NULL, NULL);
 
   ... // use the array buffer
 
@@ -5540,12 +5542,6 @@ jerry_arraybuffer_write (const jerry_value_t value,
 **Summary**
 
 The function allows access to the contents of the Array Buffer directly.
-Only allowed for Array Buffers which were created with
-[jerry_create_arraybuffer_external](#jerry_create_arraybuffer_external)
-function calls. In any other case this function will return `NULL`.
-
-After using the pointer the [jerry_release_value](#jerry_release_value)
-function must be called.
 
 **WARNING!** This operation is for expert use only! The programmer must
 ensure that the returned memory area is used correctly. That is
@@ -5577,9 +5573,6 @@ jerry_get_arraybuffer_pointer (const jerry_value_t value);
   {
     data[i] = (uint8_t) (i + 4);
   }
-
-  // required after jerry_get_arraybuffer_pointer call.
-  jerry_release_value (buffer);
 
   // use the Array Buffer
 

--- a/deps/jerry/jerry-core/api/jerry.c
+++ b/deps/jerry/jerry-core/api/jerry.c
@@ -2955,6 +2955,7 @@ jerry_create_arraybuffer (const jerry_length_t size) /**< size of the ArrayBuffe
 jerry_value_t
 jerry_create_arraybuffer_external (const jerry_length_t size, /**< size of the buffer to used */
                                    uint8_t *buffer_p, /**< buffer to use as the ArrayBuffer's backing */
+                                   void *free_hint, /**< hint params of buffer free callback */
                                    jerry_object_native_free_callback_t free_cb) /**< buffer free callback */
 {
   jerry_assert_api_available ();
@@ -2967,6 +2968,7 @@ jerry_create_arraybuffer_external (const jerry_length_t size, /**< size of the b
 
   ecma_object_t *arraybuffer = ecma_arraybuffer_new_object_external (size,
                                                                      buffer_p,
+                                                                     free_hint,
                                                                      (ecma_object_native_free_callback_t) free_cb);
   return jerry_return (ecma_make_object_value (arraybuffer));
 #else /* CONFIG_DISABLE_ES2015_TYPEDARRAY_BUILTIN */
@@ -3131,12 +3133,8 @@ jerry_get_arraybuffer_pointer (const jerry_value_t value) /**< Array Buffer to u
   }
 
   ecma_object_t *buffer_p = ecma_get_object_from_value (buffer);
-  if (ECMA_ARRAYBUFFER_HAS_EXTERNAL_MEMORY (buffer_p))
-  {
-    jerry_acquire_value (value);
-    lit_utf8_byte_t *mem_buffer_p = ecma_arraybuffer_get_buffer (buffer_p);
-    return (uint8_t *const) mem_buffer_p;
-  }
+  lit_utf8_byte_t *mem_buffer_p = ecma_arraybuffer_get_buffer (buffer_p);
+  return (uint8_t *const) mem_buffer_p;
 #else /* CONFIG_DISABLE_ES2015_TYPEDARRAY_BUILTIN */
   JERRY_UNUSED (value);
 #endif /* !CONFIG_DISABLE_ES2015_TYPEDARRAY_BUILTIN */

--- a/deps/jerry/jerry-core/ecma/base/ecma-gc.c
+++ b/deps/jerry/jerry-core/ecma/base/ecma-gc.c
@@ -723,7 +723,7 @@ ecma_gc_free_object (ecma_object_t *object_p) /**< object to free */
 
             if (array_p->free_cb != NULL)
             {
-              (array_p->free_cb) (array_p->buffer_p);
+              (array_p->free_cb) (array_p->free_hint);
             }
           }
           else

--- a/deps/jerry/jerry-core/ecma/base/ecma-globals.h
+++ b/deps/jerry/jerry-core/ecma/base/ecma-globals.h
@@ -1415,6 +1415,7 @@ typedef struct
 {
   ecma_extended_object_t extended_object; /**< extended object part */
   void *buffer_p; /**< external buffer pointer */
+  void *free_hint; /**< hint params of buffer free callback */
   ecma_object_native_free_callback_t free_cb; /**<  the free callback for the above buffer pointer */
 } ecma_arraybuffer_external_info;
 

--- a/deps/jerry/jerry-core/ecma/operations/ecma-arraybuffer-object.c
+++ b/deps/jerry/jerry-core/ecma/operations/ecma-arraybuffer-object.c
@@ -74,6 +74,7 @@ ecma_arraybuffer_new_object (ecma_length_t length) /**< length of the arraybuffe
 ecma_object_t *
 ecma_arraybuffer_new_object_external (ecma_length_t length, /**< length of the buffer_p to use */
                                       void *buffer_p, /**< pointer for ArrayBuffer's buffer backing */
+                                      void *free_hint, /**< hint params of buffer free callback */
                                       ecma_object_native_free_callback_t free_cb) /**< buffer free callback */
 {
   ecma_object_t *prototype_obj_p = ecma_builtin_get (ECMA_BUILTIN_ID_ARRAYBUFFER_PROTOTYPE);
@@ -87,6 +88,7 @@ ecma_arraybuffer_new_object_external (ecma_length_t length, /**< length of the b
   array_object_p->extended_object.u.class_prop.u.length = length;
 
   array_object_p->buffer_p = buffer_p;
+  array_object_p->free_hint = free_hint;
   array_object_p->free_cb = free_cb;
 
   return object_p;

--- a/deps/jerry/jerry-core/ecma/operations/ecma-arraybuffer-object.h
+++ b/deps/jerry/jerry-core/ecma/operations/ecma-arraybuffer-object.h
@@ -37,6 +37,7 @@ ecma_arraybuffer_new_object (ecma_length_t lengh);
 ecma_object_t *
 ecma_arraybuffer_new_object_external (ecma_length_t length,
                                       void *buffer_p,
+                                      void *free_hint,
                                       ecma_object_native_free_callback_t free_cb);
 lit_utf8_byte_t *
 ecma_arraybuffer_get_buffer (ecma_object_t *obj_p) __attr_pure___;

--- a/deps/jerry/jerry-core/include/jerryscript-core.h
+++ b/deps/jerry/jerry-core/include/jerryscript-core.h
@@ -479,6 +479,7 @@ bool jerry_value_is_arraybuffer (const jerry_value_t value);
 jerry_value_t jerry_create_arraybuffer (const jerry_length_t size);
 jerry_value_t jerry_create_arraybuffer_external (const jerry_length_t size,
                                                  uint8_t *buffer_p,
+                                                 void *free_hint,
                                                  jerry_object_native_free_callback_t free_cb);
 jerry_length_t jerry_arraybuffer_write (const jerry_value_t value,
                                         jerry_length_t offset,

--- a/deps/jerry/tests/unit-core/test-arraybuffer.c
+++ b/deps/jerry/tests/unit-core/test-arraybuffer.c
@@ -274,7 +274,7 @@ main (void)
     uint8_t buffer_p[buffer_size];
     memset (buffer_p, base_value, buffer_size);
 
-    jerry_value_t arrayb = jerry_create_arraybuffer_external (buffer_size, buffer_p, test_free_cb);
+    jerry_value_t arrayb = jerry_create_arraybuffer_external (buffer_size, buffer_p, buffer_p, test_free_cb);
     uint8_t new_value = 123;
     jerry_length_t copied = jerry_arraybuffer_write (arrayb, 0, &new_value, 1);
     TEST_ASSERT (copied == 1);
@@ -305,7 +305,7 @@ main (void)
     const uint32_t buffer_size = 20;
     uint8_t buffer_p[buffer_size];
     {
-      jerry_value_t input_buffer = jerry_create_arraybuffer_external (buffer_size, buffer_p, NULL);
+      jerry_value_t input_buffer = jerry_create_arraybuffer_external (buffer_size, buffer_p, NULL, NULL);
       register_js_value ("input_buffer", input_buffer);
       jerry_release_value (input_buffer);
     }
@@ -341,8 +341,6 @@ main (void)
       sum += data[i];
     }
 
-    jerry_release_value (buffer);
-
     const char *eval_test_arraybuffer_p = (
       "var sum = 0;"
       "for (var i = 0; i < array.length; i++)"
@@ -364,7 +362,7 @@ main (void)
 
   /* Test ArrayBuffer external with invalid arguments */
   {
-    jerry_value_t input_buffer = jerry_create_arraybuffer_external (0, NULL, NULL);
+    jerry_value_t input_buffer = jerry_create_arraybuffer_external (0, NULL, NULL, NULL);
     TEST_ASSERT (jerry_value_has_error_flag (input_buffer));
     TEST_ASSERT (jerry_get_error_type (input_buffer) == JERRY_ERROR_RANGE);
     jerry_release_value (input_buffer);

--- a/deps/jerry/tests/unit-core/test-typedarray.c
+++ b/deps/jerry/tests/unit-core/test-typedarray.c
@@ -239,7 +239,7 @@ test_typedarray_complex_creation (test_entry_t test_entries[], /**< test cases *
 
       if (use_external_buffer)
       {
-        arraybuffer = jerry_create_arraybuffer_external (arraybuffer_size, buffer_ext, NULL);
+        arraybuffer = jerry_create_arraybuffer_external (arraybuffer_size, buffer_ext, NULL, NULL);
       }
       else
       {


### PR DESCRIPTION

- [x] `npm test` passes
- [ x] tests and/or benchmarks are included
- [x] documentation is changed or added

As ArrayBuffer's native pointer shall be a writable buffer address, an additional finalize hint is required to determine the informations of the native pointer on finalization.