### PR TITLE
jerry: reduce the argument count of ecma_op_object_get_property_names

### DIFF
--- a/deps/jerry/jerry-core/api/jerry.c
+++ b/deps/jerry/jerry-core/api/jerry.c
@@ -2692,7 +2692,7 @@ jerry_foreach_object_property (const jerry_value_t obj_val, /**< object value */
   }
 
   ecma_object_t *object_p = ecma_get_object_from_value (obj_value);
-  ecma_collection_header_t *names_p = ecma_op_object_get_property_names (object_p, false, true, true);
+  ecma_collection_header_t *names_p = ecma_op_object_get_property_names (object_p, ECMA_LIST_ENUMERABLE_PROTOTYPE);
   ecma_value_t *ecma_value_p = ecma_collection_iterator_init (names_p);
 
   ecma_value_t property_value = ECMA_VALUE_EMPTY;

--- a/deps/jerry/jerry-core/ecma/base/ecma-globals.h
+++ b/deps/jerry/jerry-core/ecma/base/ecma-globals.h
@@ -327,6 +327,24 @@ typedef enum
 } ecma_property_types_t;
 
 /**
+ * Property name listing options.
+ */
+typedef enum
+{
+  ECMA_LIST_NO_OPTS = (0), /**< no options are provided */
+  ECMA_LIST_ARRAY_INDICES = (1 << 0), /**< exclude properties with names
+                                       *   that are not indices */
+  ECMA_LIST_ENUMERABLE = (1 << 1), /**< exclude non-enumerable properties */
+  ECMA_LIST_PROTOTYPE = (1 << 2), /**< list properties from prototype chain */
+} ecma_list_properties_options_t;
+
+/**
+ * List enumerable properties and include the prototype chain.
+ */
+#define ECMA_LIST_ENUMERABLE_PROTOTYPE (ECMA_LIST_ENUMERABLE | ECMA_LIST_PROTOTYPE)
+
+
+/**
  * Property type mask.
  */
 #define ECMA_PROPERTY_TYPE_MASK 0x3

--- a/deps/jerry/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
+++ b/deps/jerry/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
@@ -1165,7 +1165,7 @@ ecma_builtin_array_prototype_object_sort (ecma_value_t this_arg, /**< this argum
 
   uint32_t len = ecma_number_to_uint32 (len_number);
 
-  ecma_collection_header_t *array_index_props_p = ecma_op_object_get_property_names (obj_p, true, false, false);
+  ecma_collection_header_t *array_index_props_p = ecma_op_object_get_property_names (obj_p, ECMA_LIST_ARRAY_INDICES);
 
   uint32_t defined_prop_count = 0;
   uint32_t copied_num = 0;

--- a/deps/jerry/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.c
+++ b/deps/jerry/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.c
@@ -197,10 +197,9 @@ ecma_builtin_helper_object_get_properties (ecma_object_t *obj_p, /**< object */
 
   uint32_t index = 0;
 
-  ecma_collection_header_t *props_p = ecma_op_object_get_property_names (obj_p,
-                                                                         false,
-                                                                         only_enumerable_properties,
-                                                                         false);
+  ecma_collection_header_t *props_p;
+  props_p = ecma_op_object_get_property_names (obj_p,
+                                               only_enumerable_properties ? ECMA_LIST_ENUMERABLE : ECMA_LIST_NO_OPTS);
 
   ecma_value_t *ecma_value_p = ecma_collection_iterator_init (props_p);
 

--- a/deps/jerry/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
+++ b/deps/jerry/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
@@ -741,7 +741,7 @@ ecma_builtin_json_walk (ecma_object_t *reviver_p, /**< reviver function */
   {
     ecma_object_t *object_p = ecma_get_object_from_value (value_get);
 
-    ecma_collection_header_t *props_p = ecma_op_object_get_property_names (object_p, false, true, false);
+    ecma_collection_header_t *props_p = ecma_op_object_get_property_names (object_p, ECMA_LIST_ENUMERABLE);
 
     ecma_value_t *ecma_value_p = ecma_collection_iterator_init (props_p);
 
@@ -1532,7 +1532,7 @@ ecma_builtin_json_object (ecma_object_t *obj_p, /**< the object*/
   {
     property_keys_p = ecma_new_values_collection ();
 
-    ecma_collection_header_t *props_p = ecma_op_object_get_property_names (obj_p, false, true, false);
+    ecma_collection_header_t *props_p = ecma_op_object_get_property_names (obj_p, ECMA_LIST_ENUMERABLE);
 
     ecma_value_t *ecma_value_p = ecma_collection_iterator_init (props_p);
 

--- a/deps/jerry/jerry-core/ecma/builtin-objects/ecma-builtin-object.c
+++ b/deps/jerry/jerry-core/ecma/builtin-objects/ecma-builtin-object.c
@@ -313,7 +313,7 @@ ecma_builtin_object_object_seal (ecma_value_t this_arg, /**< 'this' argument */
     /* 2. */
     ecma_object_t *obj_p = ecma_get_object_from_value (arg);
 
-    ecma_collection_header_t *props_p = ecma_op_object_get_property_names (obj_p, false, false, false);
+    ecma_collection_header_t *props_p = ecma_op_object_get_property_names (obj_p, ECMA_LIST_NO_OPTS);
 
     ecma_value_t *ecma_value_p = ecma_collection_iterator_init (props_p);
 
@@ -386,7 +386,7 @@ ecma_builtin_object_object_freeze (ecma_value_t this_arg, /**< 'this' argument *
     /* 2. */
     ecma_object_t *obj_p = ecma_get_object_from_value (arg);
 
-    ecma_collection_header_t *props_p = ecma_op_object_get_property_names (obj_p, false, false, false);
+    ecma_collection_header_t *props_p = ecma_op_object_get_property_names (obj_p, ECMA_LIST_NO_OPTS);
 
     ecma_value_t *ecma_value_p = ecma_collection_iterator_init (props_p);
 
@@ -508,7 +508,7 @@ ecma_builtin_object_object_is_sealed (ecma_value_t this_arg, /**< 'this' argumen
       is_sealed = true;
 
       /* 2. */
-      ecma_collection_header_t *props_p = ecma_op_object_get_property_names (obj_p, false, false, false);
+      ecma_collection_header_t *props_p = ecma_op_object_get_property_names (obj_p, ECMA_LIST_NO_OPTS);
 
       ecma_value_t *ecma_value_p = ecma_collection_iterator_init (props_p);
 
@@ -578,7 +578,7 @@ ecma_builtin_object_object_is_frozen (ecma_value_t this_arg, /**< 'this' argumen
       is_frozen = true;
 
       /* 2. */
-      ecma_collection_header_t *props_p = ecma_op_object_get_property_names (obj_p, false, false, false);
+      ecma_collection_header_t *props_p = ecma_op_object_get_property_names (obj_p, ECMA_LIST_NO_OPTS);
 
       ecma_value_t *ecma_value_p = ecma_collection_iterator_init (props_p);
 
@@ -825,7 +825,7 @@ ecma_builtin_object_object_define_properties (ecma_value_t this_arg, /**< 'this'
 
     ecma_object_t *props_p = ecma_get_object_from_value (props);
     /* 3. */
-    ecma_collection_header_t *prop_names_p = ecma_op_object_get_property_names (props_p, false, true, false);
+    ecma_collection_header_t *prop_names_p = ecma_op_object_get_property_names (props_p, ECMA_LIST_ENUMERABLE);
     uint32_t property_number = prop_names_p->item_count;
 
     ecma_value_t *ecma_value_p = ecma_collection_iterator_init (prop_names_p);

--- a/deps/jerry/jerry-core/ecma/operations/ecma-objects.c
+++ b/deps/jerry/jerry-core/ecma/operations/ecma-objects.c
@@ -1346,11 +1346,7 @@ ecma_op_object_is_prototype_of (ecma_object_t *base_p, /**< base object */
  */
 ecma_collection_header_t *
 ecma_op_object_get_property_names (ecma_object_t *obj_p, /**< object */
-                                   bool is_array_indices_only, /**< true - exclude properties with names
-                                                                *          that are not indices */
-                                   bool is_enumerable_only, /**< true - exclude non-enumerable properties */
-                                   bool is_with_prototype_chain) /**< true - list properties from prototype chain,
-                                                                  *   false - list only own properties */
+                                   uint32_t opts) /**< any combination of ecma_list_properties_options_t values  */
 {
   JERRY_ASSERT (obj_p != NULL
                 && !ecma_is_lexical_environment (obj_p));
@@ -1360,6 +1356,9 @@ ecma_op_object_get_property_names (ecma_object_t *obj_p, /**< object */
 
   const ecma_object_type_t type = ecma_get_object_type (obj_p);
   const bool obj_is_builtin = ecma_get_object_is_builtin (obj_p);
+  const bool is_enumerable_only = (const bool) (opts & ECMA_LIST_ENUMERABLE);
+  const bool is_array_indices_only = (const bool) (opts & ECMA_LIST_ARRAY_INDICES);
+  const bool is_with_prototype_chain = (const bool) (opts & ECMA_LIST_PROTOTYPE);
 
   const size_t bitmap_row_size = sizeof (uint32_t) * JERRY_BITSINBYTE;
   uint32_t names_hashes_bitmap[ECMA_OBJECT_HASH_BITMAP_SIZE / bitmap_row_size];

--- a/deps/jerry/jerry-core/ecma/operations/ecma-objects.h
+++ b/deps/jerry/jerry-core/ecma/operations/ecma-objects.h
@@ -47,8 +47,7 @@ bool ecma_op_object_get_own_property_descriptor (ecma_object_t *object_p, ecma_s
                                                  ecma_property_descriptor_t *prop_desc_p);
 ecma_value_t ecma_op_object_has_instance (ecma_object_t *obj_p, ecma_value_t value);
 bool ecma_op_object_is_prototype_of (ecma_object_t *base_p, ecma_object_t *target_p);
-ecma_collection_header_t * ecma_op_object_get_property_names (ecma_object_t *obj_p, bool is_array_indices_only,
-                                                              bool is_enumerable_only, bool is_with_prototype_chain);
+ecma_collection_header_t * ecma_op_object_get_property_names (ecma_object_t *obj_p, uint32_t opts);
 
 lit_magic_string_id_t ecma_object_get_class_name (ecma_object_t *obj_p);
 bool ecma_object_class_is (ecma_object_t *object_p, uint32_t class_id);

--- a/deps/jerry/jerry-core/vm/opcodes.c
+++ b/deps/jerry/jerry-core/vm/opcodes.c
@@ -264,7 +264,8 @@ opfunc_for_in (ecma_value_t left_value, /**< left value */
                     compl_val);
 
     ecma_object_t *obj_p = ecma_get_object_from_value (obj_expr_value);
-    ecma_collection_header_t *prop_names_coll_p = ecma_op_object_get_property_names (obj_p, false, true, true);
+    ecma_collection_header_t *prop_names_coll_p;
+    prop_names_coll_p = ecma_op_object_get_property_names (obj_p, ECMA_LIST_ENUMERABLE_PROTOTYPE);
 
     if (prop_names_coll_p->item_count != 0)
     {


### PR DESCRIPTION
Picked from upstream https://github.com/jerryscript-project/jerryscript/pull/2598

A pre-requirement to Symbol implementation. Which simplifies future support of [Object.getOwnPropertySymbols](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertySymbols).

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added (No API has changed)
