### PR TITLE
n-api: data pointer was NULL on getting typed array info

### DIFF
--- a/src/napi/node_api_value.c
+++ b/src/napi/node_api_value.c
@@ -335,7 +335,7 @@ napi_status napi_get_typedarray_info(napi_env env, napi_value typedarray,
    * WARNING: if the arraybuffer is managed by js engine,
    * write beyond address limit may lead to an unpredictable result.
    */
-  uint8_t* ptr = jerry_get_arraybuffer_pointer(jval);
+  uint8_t* ptr = jerry_get_arraybuffer_pointer(jval_arraybuffer);
 
   NAPI_ASSIGN(type, ntype);
   NAPI_ASSIGN(length, jlength);

--- a/test/napi/napi_typedarray.c
+++ b/test/napi/napi_typedarray.c
@@ -37,13 +37,17 @@ static napi_value Multiply(napi_env env, napi_callback_info info) {
   napi_value input_buffer;
   size_t byte_offset;
   size_t i, length;
-  NAPI_CALL(env, napi_get_typedarray_info(env, input_array, &type, &length,
-                                          NULL, &input_buffer, &byte_offset));
+  void* typed_data;
+  NAPI_CALL(env,
+            napi_get_typedarray_info(env, input_array, &type, &length,
+                                     &typed_data, &input_buffer, &byte_offset));
 
   void* data;
   size_t byte_length;
   NAPI_CALL(env,
             napi_get_arraybuffer_info(env, input_buffer, &data, &byte_length));
+  NAPI_ASSERT(env, typed_data == data,
+              "typed array data pointer shall be equal with array buffer");
 
   napi_value output_buffer;
   void* output_ptr = NULL;


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
