### PR TITLE
mqtt: change the option `keepalive` in seconds.

### DIFF
--- a/src/js/mqtt.js
+++ b/src/js/mqtt.js
@@ -40,7 +40,7 @@ function MqttClient(endpoint, options) {
     password: null,
     clientId: 'mqttjs_' + Math.random().toString(16).substr(2, 8),
     will: null,
-    keepalive: 60 * 1000,
+    keepalive: 60,
     reconnectPeriod: 5000,
     connectTimeout: 30 * 1000,
     resubscribe: true,
@@ -224,6 +224,10 @@ MqttClient.prototype._write = function(buffer, callback) {
  */
 MqttClient.prototype._keepAlive = function() {
   var self = this;
+  if (self._options.keepalive === 0) {
+    // set to 0 to disable
+    return;
+  }
   self._keepAliveTimer = setTimeout(function() {
     try {
       var buf = self._handle._getPingReq();
@@ -236,7 +240,7 @@ MqttClient.prototype._keepAlive = function() {
     self._keepAliveTimeout = setTimeout(function() {
       self.disconnect(new Error('keepalive timeout'));
     }, self._options.pingReqTimeout);
-  }, self._options.keepalive);
+  }, self._options.keepalive * 1000);
 };
 
 MqttClient.prototype._onKeepAlive = function() {

--- a/test/run_pass/test_mqtt_client.js
+++ b/test/run_pass/test_mqtt_client.js
@@ -10,6 +10,7 @@ function test(testHost) {
     reconnectPeriod: -1
   });
   assert.equal(client.reconnecting, false);
+  assert.equal(client._options.keepalive, 60); // default is 60 in seconds
   // FIXME
   // testHost may not be able to connect, so don't use mustCall here
   client.once('connect', function() {


### PR DESCRIPTION
The MQTT protocol uses this option in seconds, the current 60*1000
causes the mqtt keep alive is too long from server-side.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
