### PR TITLE
iotjs: error.__stack__ should be non-enumerable

### DIFF
--- a/src/js/iotjs.js
+++ b/src/js/iotjs.js
@@ -175,16 +175,16 @@
       enumerable: false,
       get: function() {
         if (this.__stack__ === undefined) {
-          this.__stack__ = `${this.name || 'Error'}: ${this.message}\n` +
-            makeStackTrace(this.__frames__ || []);
+          Object.defineProperty(this, '__stack__', {
+            configurable: true,
+            writable: true,
+            enumerable: false,
+            value: `${this.name || 'Error'}: ${this.message}\n` +
+              makeStackTrace(this.__frames__ || [])
+          });
         }
         return this.__stack__;
       },
-    },
-    __stack__: {
-      configurable: true,
-      writable: true,
-      enumerable: false,
     },
   };
   Object.defineProperties(Error.prototype, stackPropertiesDescriptor);


### PR DESCRIPTION
`error.__stack` should be a private property.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
